### PR TITLE
installer tweak for freebsd

### DIFF
--- a/web-install.sh
+++ b/web-install.sh
@@ -10,7 +10,7 @@ chmod +x luvi
 
 # Download lit source and build self
 LIT_ZIP=https://github.com/luvit/lit/archive/$LIT_VERSION.tar.gz
-curl -L $LIT_ZIP | tar -xzv
+curl -L $LIT_ZIP | tar -xzvf -
 BASE=lit-$LIT_VERSION
 LIT_CONFIG=$BASE/litconfig
 echo "database: $BASE/litdb.git" > $LIT_CONFIG


### PR DESCRIPTION
```
100   403    0   403    0     0   1834      0 --:--:-- --:--:-- --:--:--  1840
100 3488k  100 3488k    0     0   936k      0  0:00:03  0:00:03 --:--:-- 1206k
tar: Error opening archive: Failed to open '/dev/sa0'
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   116    0   116    0     0    600      0 --:--:-- --:--:-- --:--:--   597
curl: (23) Failed writing body (0 != 1370)
cannot create lit-0.9.3/litconfig: No such file or directory
ERROR: /root/lit-0.9.3 is not a zip file or a folder
./luvi v0.7.0

zlib: 1.2.8
ssl: OpenSSL 1.0.1l 15 Jan 2015, lua-openssl 0.4.0

Usage:
```

With this tweak the install still errors out with:

```
...
x lit-0.9.3/package.lua
x lit-0.9.3/tests/
x lit-0.9.3/tests/run.sh
x lit-0.9.3/tests/test-offline.sh
x lit-0.9.3/tests/test-pull.sh
x lit-0.9.3/tests/test-push.sh
x lit-0.9.3/tests/test-server.sh
x lit-0.9.3/web-install.sh
lit version: 0.9.3
command: make lit-0.9.3
load config: lit-0.9.3/litconfig
update config: lit-0.9.3/litconfig
fail: [string "bundle:lib/pkg.lua"]:29: [string "/root/lit-0.9.3"]:1: unexpected symbol near 'char(3)'
stack traceback:
	[C]: in function 'assert'
	[string "bundle:lib/pkg.lua"]:29: in function 'evalModule'
	[string "bundle:lib/pkg.lua"]:67: in function 'query'
	[string "bundle:lib/core.lua"]:357: in function 'make'
	[string "bundle:commands/make.lua"]:9: in function 'fn'
	[string "bundle:modules/require.lua"]:189: in function 'formatter'
	[string "bundle:modules/require.lua"]:172: in function 'loader'
	[string "bundle:modules/require.lua"]:98: in function 'finder'
	[string "bundle:modules/require.lua"]:251: in function 'require'
	[string "bundle:main.lua"]:12: in function <[string "bundle:main.lua"]:8>
	[C]: in function 'xpcall'
	[string "bundle:main.lua"]:8: in function <[string "bundle:main.lua"]:6>
```