### PR TITLE
Add zipfile support to reading APIs in core

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,3 @@
-test-offline
-test-pull
-test-push
-test-server
+test*
 lit
-test
 luvi

--- a/alias.sh
+++ b/alias.sh
@@ -1,2 +1,2 @@
-# source this to create a lit alias that runs directly our of this dir in dev mode.
+# source this to create a lit-dev alias that runs directly our of this dir in dev mode.
 alias lit-dev=LUVI_APP=`pwd`' '`which lit`

--- a/dev.fish
+++ b/dev.fish
@@ -1,0 +1,9 @@
+# source this to create a lit-def function that runs directly our of this dir in dev mode.
+set lit_dir (pwd)
+set lit_bin (pwd)/lit
+
+function lit-dev
+  set -x LUVI_APP $lit_dir
+  eval $lit_bin $argv
+  set -e LUVI_APP
+end

--- a/lib/README
+++ b/lib/README
@@ -48,7 +48,7 @@ db.isOwner(org, author) -> bool        - Check if a user is an org owner
 db.addOwner(org, author)               - Add a new owner
 db.removeOwner(org, author)            - Remove an owner
 
-db.import(path) -> kind, hash          - Import a file or tree into database
+db.import(fs, path) -> kind, hash      - Import a file or tree into database
 db.export(hash, path) -> kind          - Export a hash to a path
 
 
@@ -72,7 +72,7 @@ Package Metadata Commands
 
 These commands work with packages metadata.
 
-pkg.query(path) -> meta, path               - Query an on-disk path for package info.
+pkg.query(fs, path) -> meta, path           - Query an on-disk path for package info.
 pkg.queryDb(db, path) -> meta, kind         - Query an in-db hash for package info.
 pky.normalize(meta) -> author, tag, version - Extract and normalize pkg info
 

--- a/lib/core.lua
+++ b/lib/core.lua
@@ -181,7 +181,7 @@ return function (db, config, getKey)
     end
   end
 
-  function core.addDep(deps, fs, modulesDir, alias, author, name, version)
+  local function addDep(deps, fs, modulesDir, alias, author, name, version)
     -- Check for existing packages in the "modules" dir on disk
     if modulesDir then
       local meta, path = pkg.query(fs, pathJoin(modulesDir, alias))
@@ -267,7 +267,7 @@ return function (db, config, getKey)
         error("Package names must include owner/name at a minimum")
       end
       if version then version = normalize(version) end
-      core.addDep(deps, fs, modulesDir, alias, author, name, version)
+      addDep(deps, fs, modulesDir, alias, author, name, version)
     end
     local hashes = {}
     for i = 1, #deps do

--- a/lib/pkg.lua
+++ b/lib/pkg.lua
@@ -4,14 +4,13 @@ Package Metadata Commands
 
 These commands work with packages metadata.
 
-pkg.query(path) -> meta, path               - Query an on-disk path for package info.
+pkg.query(fs, path) -> meta, path           - Query an on-disk path for package info.
 pkg.queryDb(db, path) -> meta, kind         - Query an in-db hash for package info.
 pky.normalize(meta) -> author, tag, version - Extract and normalize pkg info
 ]]
 
 local isFile = require('git').modes.isFile
 local semver = require('semver')
-local fs = require('coro-fs')
 local pathJoin = require('luvi').path.join
 local listToMap = require('git').listToMap
 
@@ -44,7 +43,7 @@ local function evalModule(data, name)
 end
 
 
-function exports.query(path)
+function exports.query(fs, path)
   local packagePath = path
   local stat, data, err
   stat, err = fs.stat(path)

--- a/lib/vfs.lua
+++ b/lib/vfs.lua
@@ -1,0 +1,111 @@
+local fs = require('coro-fs')
+local miniz = require('miniz')
+local pathJoin = require('luvi').path.join
+
+local function zipFs(zip, autoChroot)
+  local zfs = {}
+
+  local prefix = "./"
+
+  local function locateFile(path)
+    local index, err = zip:locate_file(path)
+    if index then return index end
+    if err:match("^Can't find file") then
+      err = "ENOENT: " .. err
+    end
+    return nil, err
+  end
+
+  function zfs.stat(path)
+    path = pathJoin(prefix .. path)
+    if path == "" then
+      return {
+        type = "directory",
+        mode = 493
+      }
+    end
+    local err
+    local index = locateFile(path)
+    if not index then
+      index, err = locateFile(path .. "/")
+      if not index then return nil, err end
+    end
+    local raw = zip:stat(index)
+    local typ = raw.filename:sub(-1) == "/" and "directory" or "file"
+    return {
+      type = typ,
+      size = raw.uncomp_size,
+      mtime = raw.time,
+      mode = typ == "directory" and 493 or 420
+    }
+  end
+  function zfs.scandir(path)
+    path = pathJoin(prefix .. path)
+    local index, err
+    if path == "" then
+      index = 0
+    else
+      path = path .. "/"
+      index, err = locateFile(path)
+      if not index then return nil, err end
+      if not zip:is_directory(index) then
+        return nil, path .. " is not a directory"
+      end
+    end
+    local i = index + 1
+    local num = zip:get_num_files()
+    return function ()
+      while i < num do
+        local filename = zip:get_filename(i)
+        i = i + 1
+        if string.sub(filename, 1, #path) ~= path then return end
+        filename = filename:sub(#path + 1)
+        local typ = "file"
+        local n = string.find(filename, "/")
+        if n == #filename then
+          filename = string.sub(filename, 1, #filename - 1)
+          typ = "directory"
+          n = nil
+        end
+        if not n then
+          return {
+            name = filename,
+            type = typ,
+            mode = typ == "directory" and 493 or 420
+          }
+        end
+      end
+    end
+  end
+  function zfs.readFile(path)
+    path = pathJoin(prefix .. path)
+    local index, err = locateFile(path)
+    if not index then return nil, err end
+    return zip:extract(index)
+  end
+
+  -- Check for zips with single folder at root
+  if autoChroot then
+    local entries = {}
+    for entry in zfs.scandir("") do
+      entries[#entries + 1] = entry
+      if #entries > 1 then break end
+    end
+    if #entries == 1 and entries[1].type == "directory" then
+      prefix = entries[1].name .. "/"
+    end
+  end
+
+  return zfs
+end
+
+return function (path)
+p{path=path}
+  local zip = miniz.new_reader(path)
+  if zip then
+    return zipFs(zip, true), ""
+  else
+    return fs, path
+  end
+end
+

--- a/package.lua
+++ b/package.lua
@@ -1,6 +1,6 @@
 return {
   name = "creationix/lit",
-  version = "0.9.7",
+  version = "0.9.8",
   dependencies = {
     "creationix/pretty-print@0.1.0",
     "creationix/require@1.0.2",

--- a/web-install.ps1
+++ b/web-install.ps1
@@ -1,3 +1,7 @@
+
+$LIT_VERSION = "0.9.7"
+$LUVI_VERSION = "0.7.0"
+
 function Download-File {
 param (
   [string]$url,
@@ -9,16 +13,6 @@ param (
   $downloader.DownloadFile($url, $file)
 }
 
-$LIT_VERSION = "0.9.7"
-$LUVI_VERSION = "0.7.0"
-
-if ($env:TEMP -eq $null) {
-  $env:TEMP = Join-Path $env:SystemDrive 'temp'
-}
-$luviTempDir = Join-Path $env:TEMP "luvi"
-$tempDir = Join-Path $luviTempDir "lit"
-if (![System.IO.Directory]::Exists($tempDir)) {[System.IO.Directory]::CreateDirectory($tempDir)}
-
 # download the package
 Write-Host "Download Luvi"
 $luviUrl = "https://github.com/luvit/luvi/releases/download/v$LUVI_VERSION/luvi-static-Windows-amd64.exe"
@@ -29,15 +23,7 @@ $litPackage = "https://github.com/luvit/lit/archive/$LIT_VERSION.zip"
 $litFile = "lit.zip"
 Download-File $litPackage $litFile
 
-# download 7zip
-Write-Host "Download 7Zip commandline tool"
-$7zaExe = Join-Path $tempDir '7za.exe'
-Download-File 'https://chocolatey.org/7za.exe' "$7zaExe"
-
 # Create Lit.exe
-Start-Process "$7zaExe" -ArgumentList "x -o`"$tempDir`" -y `"$litFile`"" -Wait -NoNewWindow
-$env:LUVI_APP="$tempDir\lit-$LIT_VERSION"
-$env:LUVI_TARGET="lit.exe"
-Start-Process "luvi.exe" -Wait -NoNewWindow
+$env:LUVI_APP="$litFile"
+Start-Process "luvi.exe" -ArgumentList "make $litFile" -Wait -NoNewWindow
 $env:LUVI_APP=""
-$env:LUVI_TARGET=""

--- a/web-install.ps1
+++ b/web-install.ps1
@@ -1,6 +1,6 @@
 
-$LUVI_VERSION = "0.7.0"
-$LIT_VERSION = "0.9.7"
+$LUVI_VERSION = "0.7.1"
+$LIT_VERSION = "0.9.8"
 
 $LUVI_ARCH = "Windows-amd64"
 $LUVI_URL = "https://github.com/luvit/luvi/releases/download/v$LUVI_VERSION/luvi-static-$LUVI_ARCH.exe"

--- a/web-install.ps1
+++ b/web-install.ps1
@@ -1,6 +1,10 @@
 
-$LIT_VERSION = "0.9.7"
 $LUVI_VERSION = "0.7.0"
+$LIT_VERSION = "0.9.7"
+
+$LUVI_ARCH = "Windows-amd64"
+$LUVI_URL = "https://github.com/luvit/luvi/releases/download/v$LUVI_VERSION/luvi-static-$LUVI_ARCH.exe"
+$LIT_URL = "https://github.com/luvit/lit/archive/$LIT_VERSION.zip"
 
 function Download-File {
 param (
@@ -13,17 +17,15 @@ param (
   $downloader.DownloadFile($url, $file)
 }
 
-# download the package
-Write-Host "Download Luvi"
-$luviUrl = "https://github.com/luvit/luvi/releases/download/v$LUVI_VERSION/luvi-static-Windows-amd64.exe"
-Download-File $luviUrl "luvi.exe"
+# Download Files
+Download-File $LUVI_URL "luvi.exe"
+Download-File $LIT_URL "lit.zip"
 
-# lit package
-$litPackage = "https://github.com/luvit/lit/archive/$LIT_VERSION.zip"
-$litFile = "lit.zip"
-Download-File $litPackage $litFile
-
-# Create Lit.exe
-$env:LUVI_APP="$litFile"
-Start-Process "luvi.exe" -ArgumentList "make $litFile" -Wait -NoNewWindow
+# Create lit.exe using lit
+$env:LUVI_APP="lit.zip"
+Start-Process "luvi.exe" -ArgumentList "make lit.zip" -Wait -NoNewWindow
 $env:LUVI_APP=""
+
+# Cleanup
+Remove-Item "luvi.exe"
+Remove-Item "lit.zip"

--- a/web-install.sh
+++ b/web-install.sh
@@ -1,17 +1,21 @@
 #!/bin/sh
-# Set versions
-LUVI_VERSION=v0.7.0
+set -eu
+LUVI_VERSION=0.7.0
 LIT_VERSION=0.9.7
 
-# Download luvi binary
-LUVI_URL=https://github.com/luvit/luvi/releases/download/$LUVI_VERSION/luvi-static-`uname -s`_`uname -m`
+LUVI_ARCH=`uname -s`_`uname -m`
+LUVI_URL="https://github.com/luvit/luvi/releases/download/v$LUVI_VERSION/luvi-static-$LUVI_ARCH"
+LIT_URL="https://github.com/luvit/lit/archive/$LIT_VERSION.zip"
+
+# Download Files
+echo "Downloading $LUVI_URL to luvi"
 curl -L $LUVI_URL > luvi
 chmod +x luvi
+echo "Downloading $LIT_URL to lit.zip"
+curl -L $LIT_URL > lit.zip
 
-# Download lit source and build self
-LIT_ZIP=https://github.com/luvit/lit/archive/$LIT_VERSION.tar.gz
-curl -L $LIT_ZIP | tar -xzvf -
-BASE=lit-$LIT_VERSION
-LIT_CONFIG=$BASE/litconfig
-echo "database: $BASE/litdb.git" > $LIT_CONFIG
-LIT_CONFIG=$LIT_CONFIG LUVI_APP=$BASE ./luvi make $BASE
+# Create lit using lit
+LUVI_APP=lit.zip luvi make lit.zip
+
+# Cleanup
+rm lit.zip luvi

--- a/web-install.sh
+++ b/web-install.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -eu
-LUVI_VERSION=0.7.0
-LIT_VERSION=0.9.7
+LUVI_VERSION=0.7.1
+LIT_VERSION=0.9.8
 
 LUVI_ARCH=`uname -s`_`uname -m`
 LUVI_URL="https://github.com/luvit/luvi/releases/download/v$LUVI_VERSION/luvi-static-$LUVI_ARCH"


### PR DESCRIPTION
Now commands like `lit make`, `lit add` can work on zip files and treat them as readable directories.