### PR TITLE
Make url

### DIFF
--- a/commands/make.lua
+++ b/commands/make.lua
@@ -4,6 +4,10 @@ local pathJoin = require('luvi').path.join
 
 
 local cwd = uv.cwd()
-local app = args[2] and pathJoin(cwd, args[2]) or cwd
+local source = args[2] and pathJoin(cwd, args[2])
 local target = args[3] and pathJoin(cwd, args[3])
-core.make(app, target)
+if not source or uv.fs_access(source, "r") then
+  core.make(source or cwd, target)
+else
+  core.makeUrl(args[2], target)
+end

--- a/deps/coro-http.lua
+++ b/deps/coro-http.lua
@@ -1,8 +1,16 @@
+exports.name = "creationix/coro-http"
+exports.version = "0.1.0"
+exports.dependencies = {
+  "creationix/coro-tcp@1.0.4",
+  "creationix/coro-tls@1.1.1",
+  "creationix/coro-wrapper@0.1.0",
+  "luvit/http-codec@0.1.5"
+}
+
 local httpCodec = require('http-codec')
 local connect = require('coro-tcp').connect
 local tlsWrap = require('coro-tls').wrap
 local wrapper = require('coro-wrapper')
-local log = require('./log')
 
 local function parseUrl(url)
   local protocol, host, hostname, port, path = url:match("^(https?:)//(([^/:]+):?([0-9]*))(/?.*)$")
@@ -52,7 +60,6 @@ end
 exports.saveConnection = saveConnection
 
 function exports.request(method, url, headers, body)
-  log("Making request", method .. ' ' .. url)
   local uri = parseUrl(url)
   local connection = getConnection(uri.hostname, uri.port, uri.tls)
   local read = connection.read

--- a/deps/http-codec.lua
+++ b/deps/http-codec.lua
@@ -17,7 +17,7 @@ limitations under the License.
 --]]
 
 exports.name = "luvit/http-codec"
-exports.version = "0.1.4"
+exports.version = "0.1.5"
 
 local sub = string.sub
 local gsub = string.gsub
@@ -193,7 +193,7 @@ exports.decoder = function ()
     -- Parse the header lines
     while true do
       local key, value
-      _, offset, key, value = find(chunk, "^([^:]+): *([^\r\n]+)\r?\n", offset + 1)
+      _, offset, key, value = find(chunk, "^([^:\r\n]+): *([^\r\n]+)\r?\n", offset + 1)
       if not offset then break end
       local lowerKey = lower(key)
 

--- a/deps/require.lua
+++ b/deps/require.lua
@@ -1,7 +1,7 @@
 
 if exports then
   exports.name = "luvit/require"
-  exports.version = "0.2.1"
+  exports.version = "0.2.3"
 end
 
 local luvi = require('luvi')
@@ -178,17 +178,26 @@ local function generator(modulePath)
 
     elseif ext == binExt then
       local fnName = "luaopen_" .. name:match("[^/]+$"):match("^[^%.]+")
-      local fn
-      if uv.fs_access(path, "r") then
+      local fn, err
+      local realPath = uv.fs_access(path, "r") and path or uv.fs_access(key, "r") and key
+      if realPath then
         -- If it's a real file, load it directly
-        fn = assert(package.loadlib(path, fnName))
+        fn, err = package.loadlib(realPath, fnName)
+        if not fn then
+          error(realPath .. "#" .. fnName .. ": " .. err)
+        end
       else
         -- Otherwise, copy to a temporary folder and read from there
         local dir = assert(uv.fs_mkdtemp(pathJoin(tmpBase, "lib-XXXXXX")))
+        path = pathJoin(dir, path:match("[^/\\]+$"))
         local fd = uv.fs_open(path, "w", 384) -- 0600
         uv.fs_write(fd, data, 0)
         uv.fs_close(fd)
-        fn = assert(package.loadlib(path, fnName))
+        local err
+        fn, err = package.loadlib(path, fnName)
+        if not fn then
+          error(path .. "#" .. fnName .. ": " .. err)
+        end
         uv.fs_unlink(path)
         uv.fs_rmdir(dir)
       end

--- a/get-lit.ps1
+++ b/get-lit.ps1
@@ -1,6 +1,6 @@
 
 $LUVI_VERSION = "0.7.1"
-$LIT_VERSION = "0.10.5"
+$LIT_VERSION = "0.10.6"
 
 $LUVI_ARCH = "Windows-amd64"
 $LUVI_URL = "https://github.com/luvit/luvi/releases/download/v$LUVI_VERSION/luvi-static-$LUVI_ARCH.exe"

--- a/get-lit.sh
+++ b/get-lit.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -eu
 LUVI_VERSION=0.7.1
-LIT_VERSION=0.10.5
+LIT_VERSION=0.10.6
 
 LUVI_ARCH=static-`uname -s`_`uname -m`
 if uname -m | grep arm; then

--- a/libs/core.lua
+++ b/libs/core.lua
@@ -272,11 +272,12 @@ return function (db, config, getKey)
     end
 
     if not match then
-      if version then
-        error("No such version: " .. author .. "/" .. name .. '@' .. version)
-      else
-        error("No such package: " .. author .. '/' .. name)
-      end
+      error("No such "
+        .. (config.upstream and "" or "local ")
+        .. (version and "version" or "package") .. ": "
+        .. author .. "/" .. name
+        .. (version and '@' .. version or '')
+        .. (config.upstream and "" or " (perhaps add an upstream)"))
     end
 
     deps[alias] = {

--- a/libs/core.lua
+++ b/libs/core.lua
@@ -144,7 +144,7 @@ return function (db, config, getKey)
     for i = 1, #queue do
       local tag, version, hash = unpack(queue[i])
       if #queue == 1 or confirm(tag .. " -> " .. config.upstream .. "\nDo you wish to publish?") then
-        log("publishing", tag .. '@' .. version, "highlight")
+        log("publishing", tag, "highlight")
         db.push(hash)
       end
     end
@@ -474,7 +474,6 @@ return function (db, config, getKey)
   function core.make(path, target)
     local fs, newPath = vfs(path)
     local meta = pkg.query(fs, newPath)
-    p{fs=fs,newPath=newPath}
     if not meta then
       error("Not a package at: " .. path)
     end

--- a/libs/coro-http.lua
+++ b/libs/coro-http.lua
@@ -1,0 +1,98 @@
+local httpCodec = require('http-codec')
+local connect = require('coro-tcp').connect
+local tlsWrap = require('coro-tls').wrap
+local wrapper = require('coro-wrapper')
+local log = require('./log')
+
+local function parseUrl(url)
+  local protocol, host, hostname, port, path = url:match("^(https?:)//(([^/:]+):?([0-9]*))(/?.*)$")
+  if not protocol then error("Not a valid http url: " .. url) end
+  local tls = protocol == "https:"
+  port = port and tonumber(port) or (tls and 443 or 80)
+  if path == "" then path = "/" end
+  return {
+    tls = tls,
+    host = host,
+    hostname = hostname,
+    port = port,
+    path = path
+  }
+end
+exports.parseUrl = parseUrl
+
+local connections = {}
+
+local function getConnection(host, port, tls)
+  for i = #connections, 1, -1 do
+    local connection = connections[i]
+    if connection.host == host and connection.port == port and connection.tls == tls then
+      table.remove(connection, i)
+      return connection
+    end
+  end
+  local read, write = assert(connect(host, port))
+  if tls then
+    read, write = tlsWrap(read, write)
+  end
+  -- TODO: wrap read and write to clean up when socket terminates?
+  return {
+    host = host,
+    port = port,
+    tls = tls,
+    read = wrapper.reader(read, httpCodec.decoder()),
+    write = wrapper.writer(write, httpCodec.encoder()),
+  }
+end
+exports.getConnection = getConnection
+
+local function saveConnection(connection)
+  -- TODO: add some idle timeout or timestamp?
+  connections[#connections + 1] = connection
+end
+exports.saveConnection = saveConnection
+
+function exports.request(method, url, headers, body)
+  log("Making request", method .. ' ' .. url)
+  local uri = parseUrl(url)
+  local connection = getConnection(uri.hostname, uri.port, uri.tls)
+  local read = connection.read
+  local write = connection.write
+
+  local req = {
+    method = method,
+    path = uri.path,
+    {"Host", uri.host}
+  }
+  if headers then
+    for i = 1, #headers do
+      req[#req + 1] = headers[i]
+    end
+  end
+
+  write(req)
+  if body then write(body) end
+  local res = read()
+  body = {}
+  for item in read do
+    if #item == 0 then break end
+    body[#body + 1] = item
+  end
+
+  if res.keepAlive then
+    saveConnection(connection)
+  else
+    write()
+  end
+
+  -- Follow redirects
+  if method == "GET" and res.code == 302 then
+    for i = 1, #res do
+      local key, location = unpack(res[i])
+      if key:lower() == "location" then
+        return exports.request(method, location, headers)
+      end
+    end
+  end
+
+  return res, table.concat(body)
+end

--- a/libs/db-fs.lua
+++ b/libs/db-fs.lua
@@ -1,0 +1,107 @@
+local git = require('git')
+local listToMap = git.listToMap
+local modeToType = git.modeToType
+local modes = git.modes
+
+return function (db, root)
+  local cache = {}
+
+  local function loadAny(hash)
+    local cached = cache[hash]
+    if cached then return unpack(cached) end
+    local kind, value = db.loadAny(hash)
+    cache[hash] = {kind, value}
+    return kind, value
+  end
+
+  local function loadAs(kind, hash)
+    local actual, value = loadAny(hash)
+    if not actual then
+      error("No such hash: " .. hash)
+    end
+    if actual ~= kind then
+      error("Kind mismatch: expected " .. kind .. " but found " .. actual .. " for " .. hash)
+    end
+    return value
+  end
+
+  local function resolvePath(path)
+    local hash = root
+    local kind, value = loadAny(hash)
+    if kind == "tag" then
+      hash = value.object
+      kind = value.type
+      value = loadAs(kind, hash)
+    end
+    if kind == "commit" then
+      hash = value.tree
+      kind = "tree"
+      value = loadAs(kind, hash)
+    end
+    local mode = kind == "tree" and modes.tree or modes.blob
+    for part in path:gmatch("[^/]+") do
+      if kind == "tree" then
+        local tree = listToMap(value)
+        local entry = tree[part]
+        if not entry then
+          return nil, "ENOENT: no such entry: " .. root .. ":" .. path
+        end
+        if entry.mode == modes.commit then
+          error("Submodules not implemented yet")
+        end
+        hash = entry.hash
+        mode = entry.mode
+        kind, value = loadAny(hash)
+      else
+        return nil, "ENOENT: no such entry: " .. root .. ":" .. path
+      end
+    end
+    return kind, mode, hash, value
+  end
+
+  local function typeFromMode(mode)
+    local t = mode == modes.tree and "directory"
+      or modes.isFile(mode) and "file"
+      or mode == modes.sym and "symlink"
+      or modeToType(mode)
+    return t
+  end
+
+  local gfs = {}
+  function gfs.stat(path)
+    local kind, mode, hash = resolvePath(path)
+    if not kind then return kind, mode end
+    return {
+      hash = hash,
+      mode = mode,
+      type = typeFromMode(mode)
+    }
+  end
+  function gfs.scandir(path)
+    if path == "init.lua" then print(debug.traceback()) end
+    local kind, mode, _, value = resolvePath(path)
+    if not kind then return kind, mode end
+    if kind ~= "tree" then
+      return nil, "EINVAL: not a tree " .. root .. ":" .. path
+    end
+    local i = 1
+    return function ()
+      local entry = value[i]
+      if not entry then return end
+      i = i + 1
+      return {
+        hash = entry.hash,
+        name = entry.name,
+        mode = entry.mode,
+        type = typeFromMode(entry.mode)
+      }
+    end
+  end
+  function gfs.readFile(path)
+    local kind, mode, _, value = resolvePath(path)
+    if kind == "blob" then return value end
+    if not kind then return kind, mode end
+    return nil, "EINVAL: not a file " .. root .. ":" .. path
+  end
+  return gfs, ""
+end

--- a/libs/github-request.lua
+++ b/libs/github-request.lua
@@ -1,47 +1,28 @@
 local env = require('env')
-local httpCodec = require('http-codec')
-local connect = require('coro-tcp').connect
-local tlsWrap = require('coro-tls').wrap
-local wrapper = require('coro-wrapper')
 local log = require('./log')
 local jsonParse = require('json').parse
+local http = require('coro-http')
 
 return function (path, etag)
   local url = "https://api.github.com" .. path
   log("github request", url)
 
-  local req = {
-    method = "GET",
-    path = path,
-    {"Host", "api.github.com"},
+  local headers = {
     {"User-Agent", "lit"},
   }
 
   -- Set GITHUB_TOKEN to a token from https://github.com/settings/tokens/new to increase the rate limit
   local token = env.get("GITHUB_TOKEN")
   if token then
-    req[#req + 1] = {"Authorization", "token " .. token}
+    headers[#headers + 1] = {"Authorization", "token " .. token}
   end
 
   if etag then
-    req[#req + 1] = {"If-None-Match", etag}
+    headers[#headers + 1] = {"If-None-Match", etag}
   end
 
-  local read, write = assert(connect("api.github.com", "https"))
-  read, write = tlsWrap(read, write)
+  local head, json = http.request("GET", url, headers)
 
-  read = wrapper.reader(read, httpCodec.decoder())
-  write = wrapper.writer(write, httpCodec.encoder())
-
-  write(req)
-  local head = read()
-  local json = {}
-  for item in read do
-    if #item == 0 then break end
-    json[#json + 1] = item
-  end
-  write()
-  json = table.concat(json)
   json = jsonParse(json) or json
   return head, json, url
 end

--- a/libs/vfs.lua
+++ b/libs/vfs.lua
@@ -102,7 +102,9 @@ end
 return function (path)
   local zip = miniz.new_reader(path)
   if zip then
-    return zipFs(zip, true), ""
+    local fs, newPath = zipFs(zip, true), ""
+    fs.base = path
+    return fs, newPath
   else
     return fs, path
   end

--- a/package.lua
+++ b/package.lua
@@ -1,13 +1,14 @@
 return {
   name = "creationix/lit",
-  version = "0.10.5",
+  version = "0.10.6",
   dependencies = {
-    "luvit/require@0.2.1",
+    "luvit/require@0.2.3",
     "luvit/pretty-print@0.1.0",
-    "luvit/http-codec@0.1.4",
+    "luvit/http-codec@0.1.5",
     "luvit/json@0.1.0",
     "creationix/coro-fs@1.2.3",
     "creationix/coro-tcp@1.0.4",
+    "creationix/coro-http@0.1.0",
     "creationix/coro-tls@1.1.1",
     "creationix/coro-wrapper@0.1.0",
     "creationix/hex-bin@1.0.0",


### PR DESCRIPTION
This gives the `lit make` command url ability.  For example, the following are valid ways to build apps.

```sh
# get latest version from lit
lit make lit://luvit/luvit
# Specify a base version, gets best match
lit make lit://luvit/luvit@2.0.0
# shorthand for luvit:// prefix
lit make luvit/luvit
# Download zip from github and build from that           
lit make github://creationix/rye
# Download zip of luvi-up branch on github
lit make github://luvit/luvit@luvi-up
# Download arbitrary zip
lit make https://foo.bar.com/myapp.zip
# Make a shallow clone
lit make git://github.com/creationix/rye.git
```
