### PR TITLE
fs_scandir does not always returns the direntry type. I've changed the db.lua for a quick fix without breaking anything else

### DIFF
--- a/libs/db.lua
+++ b/libs/db.lua
@@ -289,6 +289,7 @@ return function (path)
 
       for entry in assert(fs.scandir(path)) do
         local fullPath = pathJoin(path, entry.name)
+        entry.type = entry.type or fs.stat(fullPath).type
         if isAllowed(fullPath, entry, filters) then
           entry.mode, entry.hash = importEntry(fullPath, entry)
           if entry.hash then


### PR DESCRIPTION
If you run the fs_scandir in a directory placed on a virtual shared folder (I'm using vagrant), fs_scandir does not return the *direntry* type. **The problem is on the libuv, uv_fs_scandir_next**

The file db.lua throws an error because the type is nil:
error("Unsupported type at " .. path .. ": " .. tostring(stat.type))

Here is some test using coro-fs.scan_dir:
```
local uv = require('uv')
require('luvi').bundle.register("luvit-require", "deps/require.lua")
local require = require('luvit-require')("bundle:main.lua")

local fs = require('coro-fs')
_G.p = require('pretty-print').prettyPrint
coroutine.wrap(function() 

for entry in assert(fs.scandir(".")) do
	p(entry)
end
end)()
```

**Result ran in a directory not shared**
```
vagrant@vagrant-ubuntu-trusty-32:~/luviapp$ LUVI_APP=. /vagrant/boundary/luvi/build/luvi
{ name = 'deps', type = 'directory' }
{ name = 'init.lua', type = 'file' }
{ name = 'main.lua', type = 'file' }
```

**And running the same code but in a directory (/vagrant) that IS a shared folder between the host and the guest (VM Vagrant Ubuntu) , returns the following:**

```
vagrant@vagrant-ubuntu-trusty-32:/vagrant/boundary/tests/luviapp$ LUVI_APP=. ../../luvi/build/luvi
{ name = 'deps' }
{ name = 'init.lua' }
{ name = 'main.lua' }
```

**I've tested the code running make command an works OK**