### PR TITLE
Compile Lua files when making luvi app

### DIFF
--- a/libs/core.lua
+++ b/libs/core.lua
@@ -405,6 +405,13 @@ return function (db, config, getKey)
 
   local function importBlob(writer, path, hash)
     local data = db.loadAs("blob", hash)
+    local base = path:match("^(.*)%.lua$")
+    if base then
+      log("compiling", path)
+      data = string.dump(loadstring(data), true)
+      -- TODO: rename file once require can look for it?
+      -- path = base .. ".rc"
+    end
     writer:add(path, data, 9)
   end
 

--- a/libs/core.lua
+++ b/libs/core.lua
@@ -407,10 +407,9 @@ return function (db, config, getKey)
     local data = db.loadAs("blob", hash)
     local base = path:match("^(.*)%.lua$")
     if base then
+      -- TODO: add an option to disable this in case you want uncompiled lua files.
       log("compiling", path)
-      data = string.dump(loadstring(data), true)
-      -- TODO: rename file once require can look for it?
-      -- path = base .. ".rc"
+      data = string.dump(loadstring(data, "bundle:" .. path))
     end
     writer:add(path, data, 9)
   end


### PR DESCRIPTION
This compiles all lua files when building a luvi app zip.  The final zip file isn't always smaller, but it uses a bit less ram.  Also authors can write verbose comments now without worrying about it hurting their luvi app.