### PR TITLE
print more information while version of depend package is error.

### DIFF
--- a/libs/core.lua
+++ b/libs/core.lua
@@ -333,7 +333,11 @@ return function (db, config, getKey)
       if not author then
         error("Package names must include owner/name at a minimum")
       end
-      if version then version = normalize(version) end
+      if version then 
+        local ok = false
+        ok, version = pcall(normalize, version)
+        if not ok then error("Package version is error - " .. dep) end
+      end
       addDep(deps, fs, modulesDir, alias, author, name, version)
     end
     local hashes = {}


### PR DESCRIPTION
I write my package.lua with a error:
````lua
  dependencies = {
    "creationix/weblit@a0.3.1",   -- here
    "luvit/luvit@2.1.12",
    "luvit/tap@0.1.0",
  },
````
I run "lit make" and failed with:
````
fail: [string "bundle:deps/semver.lua"]:20: Not a semver
stack traceback:
        [C]: in function 'assert'
        [string "bundle:deps/semver.lua"]:20: in function 'parse'
        [string "bundle:deps/semver.lua"]:29: in function 'normalize'
        [string "bundle:libs/core.lua"]:336: in function 'processDeps'
        [string "bundle:libs/core.lua"]:497: in function 'make'
        [string "bundle:commands/make.lua"]:10: in function 'fn'
        [string "bundle:deps/require.lua"]:275: in function 'require'
        [string "bundle:main.lua"]:32: in function <[string "bundle:main.lua"]:20>
        [C]: in function 'xpcall'
        [string "bundle:main.lua"]:20: in function <[string "bundle:main.lua"]:13>
````

I hope print  "creationix/weblit@a0.3.1" in error message.