### PR TITLE
content length header should only be sent once if specified in the list of headers.

### DIFF
--- a/deps/coro-http.lua
+++ b/deps/coro-http.lua
@@ -119,7 +119,7 @@ function exports.request(method, url, headers, body)
   end
 
   if type(body) == "string" then
-    if not (contentLength and chunked) then
+    if not chunked and not contentLength then
       req[#req + 1] = {"Content-Length", #body}
     end
   end


### PR DESCRIPTION
`not (contentLength and chunked)` is true when contentLength has a value.

`not (true and false) == true`.

it causes the content-length headers to be sent across twice, which is an issue with some services.