### PR TITLE
item was nil when the connection closed. it would still reuse the socket

### DIFF
--- a/deps/coro-http.lua
+++ b/deps/coro-http.lua
@@ -130,10 +130,15 @@ function exports.request(method, url, headers, body)
   if not res then error("Connection closed") end
 
   body = {}
-  for item in read do
+  repeat
+    local item = read()
+    if not item then
+      res.keepAlive = false
+      break
+    end
     if #item == 0 then break end
     body[#body + 1] = item
-  end
+  until false
 
   if res.keepAlive then
     saveConnection(connection)


### PR DESCRIPTION
when the connection closes item would be nil, which would cause the for loop to terminate early. however the connection would still be put back into the reuse pool.