### PR TITLE
Fix files included by default not showing up in the log

### DIFF
--- a/libs/rules.lua
+++ b/libs/rules.lua
@@ -82,16 +82,16 @@ local compileFilter = exports.compileFilter
 function exports.isAllowed(path, entry, filters)
 
   -- Ignore all hidden files and folders always.
-  local allow, subPath, default
+  local allow, matchesFilter, default, relativePath
   default = true
   for i = 1, #filters do
     local filter = filters[i]
-    local newPath = path:match(filter.prefix)
-    if newPath then
+    relativePath = path:match(filter.prefix)
+    if relativePath then
       default = filter.default
-      local newAllow = filter.match(newPath)
+      local newAllow = filter.match(relativePath)
       if newAllow ~= nil then
-        subPath = newPath
+        matchesFilter = true
         allow = newAllow
       end
     end
@@ -110,15 +110,13 @@ function exports.isAllowed(path, entry, filters)
     end
   end
 
-  if subPath then
-    if not isTree then
-      log("including", subPath)
-    elseif not allow then
-      log("skipping", subPath)
-    end
+  if allow and not isTree then
+    log("including", relativePath)
+  elseif not allow and matchesFilter then
+    log("skipping", relativePath)
   end
 
-  return allow, default, subPath
+  return allow, default, matchesFilter and relativePath
 end
 local isAllowed = exports.isAllowed
 


### PR DESCRIPTION
 * Closes #111 

I also cleaned up the variable names a bit, or I tried to. I may have gotten some stuff wrong, so let me know if I misinterpreted anything.

Output before:

```
compiling filter: C:\test/** includes by default (first rule is negative)
including: include.lua
including: nest\test.lua
including: package.lua
skipping: test
skipping: tests
```

Output after:
```
compiling filter: C:\test/** includes by default (first rule is negative)
including: extra.txt
including: include.lua
including: nest\test.lua
including: nest\test.txt
including: package.lua
skipping: test
skipping: tests
```