### PR TITLE
Snapshot feature so published lit apps have reproducible builds

### DIFF
--- a/libs/api.lua
+++ b/libs/api.lua
@@ -198,9 +198,15 @@ return function (db, prefix)
         error("Can only create zips from trees")
       end
 
-      local deps = {}
-      calculateDeps(db, deps, meta.dependencies)
-      hash = installDeps(db, hash, deps)
+      local hash
+      -- Use snapshot if there is one
+      if meta.snapshot then
+        hash = meta.snapshot
+      else
+        local deps = {}
+        calculateDeps(db, deps, meta.dependencies)
+        hash = installDeps(db, hash, deps)
+      end
 
       local zip = exportZip(db, hash)
       local filename = meta.name:match("[^/]+$") .. "-v" .. meta.version .. ".zip"

--- a/libs/core.lua
+++ b/libs/core.lua
@@ -142,6 +142,13 @@ local function makeCore(config)
       end
       error("Tag already exists, but there are local changes.\nBump " .. fullTag .. " and try again.")
     end
+    if meta.dependencies then
+      local deps = {}
+      calculateDeps(core.db, deps, meta.dependencies)
+      meta.snapshot = installDeps(core.db, hash, deps, false)
+      log("snapshot hash", meta.snapshot)
+    end
+
     local encoded = encoders.tag({
       object = hash,
       type = kind,
@@ -453,6 +460,12 @@ local function makeCore(config)
     end
 
     target = target or defaultTarget(meta)
+
+    -- Use snapshot if there is one
+    if meta.snapshot then
+      return makeZip(meta.snapshot, target)
+    end
+
     local deps = {}
     calculateDeps(core.db, deps, meta.dependencies)
     local tagObj = db.loadAs("tag", hash)

--- a/libs/core.lua
+++ b/libs/core.lua
@@ -142,7 +142,7 @@ local function makeCore(config)
       end
       error("Tag already exists, but there are local changes.\nBump " .. fullTag .. " and try again.")
     end
-    if meta.dependencies then
+    if meta.dependencies and kind == "tree" then
       local deps = {}
       calculateDeps(core.db, deps, meta.dependencies)
       meta.snapshot = installDeps(core.db, hash, deps, false)


### PR DESCRIPTION
This is a new behavior in lit.

When you add a new package to the database using `lit add` that contains dependencies and is a tree, lit will calculate the current set of dependencies for that package and save this snapshot hash along with the metadata stored in the git tag.

Then when using `lit make` with a `lit://foo/bar` url or using the `.zip` generator in the web API, the snapshot will be used to generate the zip file instead of the current set of dependencies.

This means that top-level apps will freeze all their deep dependencies at time of publish.  If an app wants to pick up big fixes in deep dependencies it will need to publish a new version.  A new build version would be enough.

But this also means that foo/bar/v1.2.3 will *always* have the same exact content and not change over time as libraries it depends on change.