### PR TITLE
Fix .gitconfig not being found on Windows when cwd is not on the home drive

### DIFF
--- a/commands/auth.lua
+++ b/commands/auth.lua
@@ -24,7 +24,7 @@ local function confirm(name, value)
   return value
 end
 
-local home = env.get("HOME") or env.get("HOMEPATH") or ""
+local home = env.get("HOME") or (env.get("HOMEDRIVE") and env.get("HOMEPATH") and (env.get("HOMEDRIVE") .. env.get("HOMEPATH"))) or env.get("HOMEPATH") or ""
 local ini
 local function getConfig(name)
   ini = ini or fs.readFile(pathJoin(home, ".gitconfig"))

--- a/commands/init.lua
+++ b/commands/init.lua
@@ -33,7 +33,7 @@ end
 
 local output = getOutput()
 
-local home = env.get("HOME") or env.get("HOMEPATH") or ""
+local home = env.get("HOME") or (env.get("HOMEDRIVE") and env.get("HOMEPATH") and (env.get("HOMEDRIVE") .. env.get("HOMEPATH"))) or env.get("HOMEPATH") or ""
 local ini
 local function getConfig(name)
   ini = ini or fs.readFile(pathJoin(home, ".gitconfig"))


### PR DESCRIPTION
 * Use %HOMEDRIVE% env var to get the correct drive, as %HOMEPATH% only contains the drive-relative path.
 * Example: %HOMEDRIVE% contains "C:", %HOMEPATH% contains "\Users\username". Putting them together gets you to full absolute path
 * More info: http://stackoverflow.com/a/2115116