### PR TITLE
git clone should be recursive so that the git submodule is pulled down.

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Or you can clone lit from git and use the Makefile which will do the same thing
 but use the files in the git clone.
 
 ```
-> git clone git@github.com:luvit/lit.git
+> git clone --recursive git@github.com:luvit/lit.git
 > cd lit
 > make
 ```


### PR DESCRIPTION
Uniaika from the IRC was having an issue where lit didn't have the git submodule. The instructions don't quite work as they are.