### PR TITLE
API: Add /packages/$AUTHOR/$TAG/latest and /packages/$AUTHOR/$TAG/latest.zip

### DIFF
--- a/libs/README
+++ b/libs/README
@@ -129,6 +129,11 @@ GET /packages/$AUTHOR/$TAG/$VERSION -> tag json {
   }
   message = "..."
 }
+GET /packages/$AUTHOR/$TAG/latest -> tag json of the most recent version
+GET /packages/$AUTHOR/$TAG/$VERSION.zip -> zip bundle of app and dependencies
+GET /packages/$AUTHOR/$TAG/latest.zip -> zip bundle of the most recent version
+
+GET /search/$query -> list of matches
 
 Server API Handlers
 ===================


### PR DESCRIPTION
 - Gets the metadata or the zip bundle of the latest version of the package
 - See #161

---

No clue if this is the optimal solution, but I figured I'd offer it as a PR just in case. Note also this makes the version parameter in the API a bit more flexible: both `/packages/author/name/v1.0.0` and `/packages/author/name/1.0.0` will work now (whereas before, the preceding `v` was required).