### PR TITLE
Add memory and file descriptor metrics to Lit server.

### DIFF
--- a/libs/api.lua
+++ b/libs/api.lua
@@ -149,7 +149,6 @@ local function collectStats()
 
     local iter = fs.scandir(path)
     for entry in iter do
-      print(entry.name)
       entries = entries + 1
     end
     return entries

--- a/libs/api.lua
+++ b/libs/api.lua
@@ -82,6 +82,7 @@ local calculateDeps = require('calculate-deps')
 local queryDb = require('pkg').queryDb
 local installDeps = require('install-deps').toDb
 local ffi = require('ffi')
+local fs = require('coro-fs')
 
 local litVersion = "Lit " .. require('../package').version
 
@@ -146,7 +147,9 @@ local function collectStats()
     -- You can confirm this yourself by hitting /metrics several times in a row,
     -- and observing that lua.fds.total does not increase with each GET request.
 
-    for entry in io.popen([[ls -1 "]]..path..[["]]):lines() do
+    local iter = fs.scandir(path)
+    for entry in iter do
+      print(entry.name)
       entries = entries + 1
     end
     return entries

--- a/libs/api.lua
+++ b/libs/api.lua
@@ -169,20 +169,20 @@ return function (db, prefix)
 
   local routes = {
     "^/metrics$", function (hash, path)
-      local entry, fds = 0, 0
-      local memoryUsed = "lua.mem.total = " .. tostring(1024 * collectgarbage("count")) .. "\n"
+      local entry, fdsUsed = 0, 0
+      local memoryUsed = 1024 * collectgarbage("count")
 
       -- You might think this leaks a filehandle, but it actually doesn't.
       -- You can confirm this yourself by hitting /metrics several times in a row,
       -- and observing that lua.fds.total does not increase with each GET request.
 
       for entry in io.popen([[ls -1 "/dev/fd"]]):lines() do
-        fds = fds + 1
+        fdsUsed = fdsUsed + 1
       end
 
-      local fdsUsed = "lua.fds.total = " .. tostring(fds) .. "\n"
-      return memoryUsed .. fdsUsed, {
-        {"Content-Type", "text/plain"}
+      return {
+        ["lua.mem.used"] = memoryUsed,
+        ["lua.fds.used"] = fdsUsed
       }
     end,
     "^/blobs/([0-9a-f]+)/(.*)", function (hash, path)


### PR DESCRIPTION
To access, hit the /metrics endpoint of the Lit server.  This will produce a
plain text, machine-readable result informing the user of the total memory
consumed by the Lit server, as well as the total number of file descriptors
used by Lit at the time the metrics were requested.