### PR TITLE
Better error message when package name is malformed

### DIFF
--- a/libs/core.lua
+++ b/libs/core.lua
@@ -129,7 +129,7 @@ local function makeCore(config)
       error("Not a package: " .. path)
     end
     local author, name, version = pkg.normalize(meta)
-    if not author or not name then
+    if not (author and name) then
       error("Malformed package metadata. Package name must be of the format 'author/package'.")
     end
     if config.upstream then core.sync(author, name) end

--- a/libs/core.lua
+++ b/libs/core.lua
@@ -129,6 +129,9 @@ local function makeCore(config)
       error("Not a package: " .. path)
     end
     local author, name, version = pkg.normalize(meta)
+    if not author or not name then
+      error("Malformed package metadata. Package name must be of the format 'author/package'.")
+    end
     if config.upstream then core.sync(author, name) end
 
     local kind, hash = import(db, fs, path)


### PR DESCRIPTION
See luvit/luvit#882

Will now give the following error instead:

```
fail: [string "bundle:libs/core.lua"]:133: Malformed package metadata. Package name must be of the format 'author/package'.
```

Note that malformed (or missing) version errors are already handled by semver.normalize within pkg.normalize.