### PR TITLE
Fix local deps not being used consistently

### DIFF
--- a/libs/get-installed.lua
+++ b/libs/get-installed.lua
@@ -26,6 +26,10 @@ return function (fs, rootPath)
     if not iter then return end
     for entry in iter do
       local baseName
+      if not entry.type then
+        local stat, err = fs.stat(pathJoin(dir, entry.name))
+        entry.type = stat and stat.type
+      end
       if entry.type == "file" then
         baseName = entry.name:match("^(.*)%.lua$")
       elseif entry.type == "directory" then

--- a/libs/pkg.lua
+++ b/libs/pkg.lua
@@ -34,10 +34,10 @@ local listToMap = require('git').listToMap
 local jsonParse = require('json').parse
 
 local function evalModule(data, name)
-  -- Match multiline lua comments that start with `lit-meta\n`
-  local a, b = data:find("%-%-%[(=*)%[lit%-meta\n")
+  -- Match multiline lua comments that start with `lit-meta`
+  local a, b = data:find("%-%-%[(=*)%[lit%-meta")
   if a then
-    local term = "]" .. data:sub(a + 3, b - 10) .."]"
+    local term = "]" .. data:sub(a + 3, b - 9) .."]"
     local c = data:find(term, b + 1, true)
     if c then
       local fn, err = loadstring(data:sub(b + 1, c - 1), name)


### PR DESCRIPTION
Closes #184. Tested and working, see https://travis-ci.org/squeek502/luvit/jobs/140012772 (no dependencies fetched from remote)

f57e2a4 is needed because the lit deps were also being fetched on Travis and locally on my Windows machine. Here's an example build without that fix included: https://travis-ci.org/squeek502/luvit/jobs/140010976

Let me know if the solutions can be improved.