### PR TITLE
add a guard for malformed package during lit install

### DIFF
--- a/libs/core.lua
+++ b/libs/core.lua
@@ -204,7 +204,7 @@ local function makeCore(config)
       local stdout = exec(exe, "-v")
       if jit.os == "Windows" then
         stdout = stdout:gsub('.exe','')
-      end      
+      end
       local iversion = stdout:match("luvi version: v(%d+%.%d+%.%d+)")
                     or stdout:match("luvi v(%d+%.%d+%.%d+)")
       if iversion == version then
@@ -524,6 +524,11 @@ local function makeCore(config)
 
   function core.installDeps(path)
     local meta = pkg.query(gfs, path)
+    -- meta will be
+    -- if not meta then
+    --   error("error in package file: " .. path)
+    --   return
+    -- end
     if not meta.dependencies then
       log("no dependencies", path)
       return

--- a/libs/core.lua
+++ b/libs/core.lua
@@ -524,11 +524,11 @@ local function makeCore(config)
 
   function core.installDeps(path)
     local meta = pkg.query(gfs, path)
-    -- meta will be
-    -- if not meta then
-    --   error("error in package file: " .. path)
-    --   return
-    -- end
+    -- meta will be `nil` if package is malformed
+    if not meta then
+      error("error in package file: " .. path)
+      return
+    end
     if not meta.dependencies then
       log("no dependencies", path)
       return

--- a/tests/bad-package/package.lua
+++ b/tests/bad-package/package.lua
@@ -1,0 +1,13 @@
+return {
+  name = "lit/bad-package-lua",
+  version = "1.0.0",
+  dependencies = {
+    "creationix/weblit-app@2.1.1"
+    "creationix/weblit-auto-headers@2.0.2"
+  },
+  files = {
+    "**.lua",
+    "!test*",
+    "!example*"
+  }
+}


### PR DESCRIPTION
I was trying to setup a project of git today, and `lit install` was failing but it wasn't clear why. I checked the `package.lua` and it had a missing comma, causing an error.

Basically, I just added a conditional in the `core.installDeps` to make sure that the package loaded correctly, and if not, it would spit out a warning letting you know the package file must be malformed.

#### Before

```
lit version: 3.4.3
luvi version: v2.7.4
command: install
load config: /Users/james/.litconfig
fail: [string "bundle:libs/core.lua"]:532: attempt to index local 'meta' (a nil value)
stack traceback:
	[string "bundle:libs/core.lua"]:532: in function 'installDeps'
	[string "bundle:commands/install.lua"]:6: in function <[string "bundle:commands/install.lua"]:1>
	[string "bundle:main.lua"]:52: in function <[string "bundle:main.lua"]:39>
	[C]: in function 'xpcall'
	[string "bundle:main.lua"]:39: in function <[string "bundle:main.lua"]:31>
```

#### After

```
lit version: 3.4.3
luvi version: v2.7.4
command: install
load config: /Users/james/.litconfig
fail: [string "bundle:libs/core.lua"]:528: error in package file: /Users/james/Sites/_git/lit/tests/bad-package
stack traceback:
	[C]: in function 'error'
	[string "bundle:libs/core.lua"]:528: in function 'installDeps'
	[string "bundle:commands/install.lua"]:6: in function <[string "bundle:commands/install.lua"]:1>
	[string "bundle:main.lua"]:52: in function <[string "bundle:main.lua"]:39>
	[C]: in function 'xpcall'
	[string "bundle:main.lua"]:39: in function <[string "bundle:main.lua"]:31>
```