### PR TITLE
WebSocket close frame and empty buffer returns

### DIFF
--- a/deps/coro-websocket.lua
+++ b/deps/coro-websocket.lua
@@ -95,6 +95,7 @@ local function wrapIo(rawRead, rawWrite, options)
             payload = message.payload
           }
         end
+        return message
       end
     end
   end

--- a/deps/coro-wrapper.lua
+++ b/deps/coro-wrapper.lua
@@ -99,6 +99,11 @@ local function decoder(read, decode)
         end
       end
 
+      -- Return nil if the buffer is empty
+      if buffer == '' or buffer == nil then
+          return nil
+      end
+
       -- If we have data, lets try to decode it
       local item, newIndex = decode(buffer, index)
 


### PR DESCRIPTION
The WebSocket standard describes a close frame, where a final message may be present.

```
5.5.1.  Close

   The Close frame contains an opcode of 0x8.

   The Close frame MAY contain a body (the "Application data" portion of
   the frame) that indicates a reason for closing, such as an endpoint
   shutting down, an endpoint having received a frame too large, or an
   endpoint having received a frame that does not conform to the format
   expected by the endpoint.  If there is a body, the first two bytes of
   the body MUST be a 2-byte unsigned integer (in network byte order)
   representing a status code with value /code/ defined in Section 7.4.
   Following the 2-byte integer, the body MAY contain UTF-8-encoded data
   with value /reason/, the interpretation of which is not defined by
   this specification.  This data is not necessarily human readable but
   may be useful for debugging or passing information relevant to the
   script that opened the connection.  As the data is not guaranteed to
   be human readable, clients MUST NOT show it to end users.
```

Here is an example close frame:

```lua
{ payload = '\015\162Error while decoding payload.', fin = true, mask = false, opcode = 8, rsv3 = false, rsv1 = false, len = 31, rsv2 = false }
```

This close message is not exposed by coro-websocket. This PR exposes it by returning the message after a close response is written from the client. This *might* break clients that do not explicitly handle messages according to their opcode, so I will leave this open to discussion. Note that I have not yet advanced the package version.