### PR TITLE
Fixes WebSocket chunk length check

### DIFF
--- a/deps/websocket-codec.lua
+++ b/deps/websocket-codec.lua
@@ -94,7 +94,7 @@ local function decode(chunk, index)
     offset = offset + 4
   end
   offset = offset + start
-  if length < offset + len then return end
+  if #chunk < offset + len then return end
 
   local first = byte(chunk, start + 1)
   local payload = sub(chunk, offset + 1, offset + len)


### PR DESCRIPTION
In #211, I replaced each `#chuck` with `length`. Apparently this line should have remained the same. The only reason why `length` can be used in the other two checks is because `length < n` is equivalent `#chunk < start + n`. Sorry for the confusion.