### PR TITLE
Fix coro-spawn hanging when uv.spawn returns an error

### DIFF
--- a/deps/coro-spawn.lua
+++ b/deps/coro-spawn.lua
@@ -54,6 +54,10 @@ return function (path, options)
 
   local handle, pid = uv.spawn(path, options, onExit)
 
+  if not handle then
+    return nil, pid
+  end
+
   -- If the process has exited already, return the cached result.
   -- Otherwise, wait for it to exit and return the result.
   local function waitExit()

--- a/libs/exec.lua
+++ b/libs/exec.lua
@@ -20,13 +20,17 @@ local spawn = require('coro-spawn')
 local split = require('coro-split')
 
 return function (command, ...)
-  local child = spawn(command, {
+  local child, err = spawn(command, {
     args = {...},
     -- Tell spawn to create coroutine pipes for stdout and stderr only
     stdio = {nil, true, true}
   })
-  local stdout, stderr, code, signal
 
+  if err then
+    return nil, err
+  end
+  
+  local stdout, stderr, code, signal
 
   -- Split the coroutine into three sub-coroutines and wait for all three.
   split(function ()


### PR DESCRIPTION
 - coro-spawn will now return nil and the error message when uv.spawn errors
 - exec will also return nil and the error message when coro-spawn errors
 - fixes #219