### PR TITLE
Add options table to request in coro-http

### DIFF
--- a/deps/coro-http.lua
+++ b/deps/coro-http.lua
@@ -102,9 +102,9 @@ local function saveConnection(connection)
   connection.socket:unref()
 end
 
-local function request(method, url, headers, body, timeout)
+local function request(method, url, headers, body, options)
   local uri = parseUrl(url)
-  local connection = getConnection(uri.hostname, uri.port, uri.tls, timeout)
+  local connection = getConnection(uri.hostname, uri.port, uri.tls, options.timeout)
   local read = connection.read
   local write = connection.write
 
@@ -174,7 +174,7 @@ local function request(method, url, headers, body, timeout)
   end
 
   -- Follow redirects
-  if method == "GET" and (res.code == 302 or res.code == 307) then
+  if method == "GET" and (res.code == 302 or res.code == 307) and not options.noredirect then
     for i = 1, #res do
       local key, location = unpack(res[i])
       if key:lower() == "location" then


### PR DESCRIPTION
I recently strolled upon a time where I had to use coro-http and not follow any redirects, but I realised that coro-http does not have this functionality built in.

This PR adds an `options` argument to the request function, which is a table of internal options
With this, I also moved the `timeout` argument into the `options` table, which makes the table currently look like:
```
options
    timeout (number)
    noredirect (boolean)
```

This also allows more options to be added over time as required.