### PR TITLE
Fix http-codec not reading full header when a header has no value

### DIFF
--- a/deps/http-codec.lua
+++ b/deps/http-codec.lua
@@ -18,7 +18,7 @@ limitations under the License.
 
 --[[lit-meta
   name = "luvit/http-codec"
-  version = "3.0.2"
+  version = "3.0.3"
   homepage = "https://github.com/luvit/luvit/blob/master/deps/http-codec.lua"
   description = "A simple pair of functions for converting between hex and raw strings."
   tags = {"codec", "http"}

--- a/deps/http-codec.lua
+++ b/deps/http-codec.lua
@@ -204,7 +204,7 @@ local function decoder()
     -- Parse the header lines
     while true do
       local key, value
-      _, offset, key, value = find(chunk, "^([^:\r\n]+): *([^\r\n]+)\r?\n", offset + 1)
+      _, offset, key, value = find(chunk, "^([^:\r\n]+): *([^\r\n]*)\r?\n", offset + 1)
       if not offset then break end
       local lowerKey = lower(key)
 


### PR DESCRIPTION
Example: "X-Geo-Block-List:" gets sent by Github gists, and the header pattern would fail and stop reading the header at that line

Fixes #232