### PR TITLE
Update core.lua

### DIFF
--- a/libs/core.lua
+++ b/libs/core.lua
@@ -380,7 +380,7 @@ local function makeCore(config)
     local tempFile = target:gsub("[^/\\]+$", ".%1.temp")
     local fd = assert(uv.fs_open(tempFile, "w", 511)) -- 0777
     local binSize
-    local inline = meta.luvi.inline
+    local inline = meta.luvi and meta.luvi.inline or false
     if inline then
       log("using inline luvi from meta", #inline)
       uv.fs_write(fd, inline, 0)


### PR DESCRIPTION
Hi,

  The latest core generate an error when make-ing
`[string "bundle:libs/core.lua"]:383: attempt to index field 'luvi' (a nil value)`

This will just walk around the error (until someone smarter will truly find it).