### PR TITLE
Fix http-codec failing occasionally during chunked decoding

### DIFF
--- a/deps/http-codec.lua
+++ b/deps/http-codec.lua
@@ -250,8 +250,9 @@ local function decoder()
     len, term = match(chunk, "^(%x+)(..)", index)
     if not len then return end
     if term ~= "\r\n" then
-      if #chunk < 34 then return end
-      -- But protect against evil clients by refusing chunk-sizes longer than 32 hex digits.
+      -- Wait for full chunk-size\r\n header
+      if #chunk < 18 then return end
+      -- But protect against evil clients by refusing chunk-sizes longer than 16 hex digits.
       error("chunk-size field too large")
     end
     index = index + #len + 2

--- a/deps/http-codec.lua
+++ b/deps/http-codec.lua
@@ -249,7 +249,11 @@ local function decoder()
     local len, term
     len, term = match(chunk, "^(%x+)(..)", index)
     if not len then return end
-    assert(term == "\r\n")
+    if term ~= "\r\n" then
+      if #chunk < 34 then return end
+      -- But protect against evil clients by refusing chunk-sizes longer than 32 hex digits.
+      error("chunk-size field too large")
+    end
     index = index + #len + 2
     local offset = index - 1
     local length = tonumber(len, 16)

--- a/deps/http-codec.lua
+++ b/deps/http-codec.lua
@@ -18,7 +18,7 @@ limitations under the License.
 
 --[[lit-meta
   name = "luvit/http-codec"
-  version = "3.0.3"
+  version = "3.0.4"
   homepage = "https://github.com/luvit/luvit/blob/master/deps/http-codec.lua"
   description = "A simple pair of functions for converting between hex and raw strings."
   tags = {"codec", "http"}


### PR DESCRIPTION
Same as https://github.com/luvit/luvit/pull/1052, but for Lit's version of `http-codec`