### PR TITLE
Make missing snapshots fall back to resolving deps individually

### DIFF
--- a/libs/core.lua
+++ b/libs/core.lua
@@ -481,7 +481,13 @@ local function makeCore(config)
     -- Use snapshot if there is one
     if meta.snapshot then
       log("using snapshot", meta.snapshot, "highlight")
-      return makeZip(meta.snapshot, target, luvi_source)
+      -- but fall back to resolving deps if we can't get the snapshot
+      local ok, err = pcall(makeZip, meta.snapshot, target, luvi_source)
+      if not ok then
+        log('failed to get snapshot', err, "failure")
+      else
+        return
+      end
     end
 
     local deps = {}


### PR DESCRIPTION
Fixes #248, addresses part of #247 

Example output from a completely clean slate (with no existing local lit db):

```
command: make lit://luvit/luvit luvit.exe luvi.exe
load config: C:\Users\Ryan\AppData\Roaming\litconfig
connecting: wss://lit.luvit.io/
fetching: 1 object
fetching: 1 object
fetching: 3 objects
using snapshot: 6e805fb6a48f25304cc6553f18a01ecc30f10e30
creating binary: C:\Users\Ryan\Programming\Luvit\lit\luvit.exe
using luvi from: C:\Users\Ryan\Programming\Luvit\lit\luvi.exe
fetching: 1 object
failed to get snapshot: [string "bundle:libs/codec.lua"]:123: No such hash: 6e805fb6a48f25304cc6553f18a01ecc30f10e30
fetching: 1 object
fetching: 1 object
fetching: 1 object
fetching: 1 object
fetching: 1 object
fetching: 1 object
fetching: 1 object
fetching: 1 object
fetching: 1 object
fetching: 1 object
fetching: 1 object
fetching: 1 object
fetching: 1 object
fetching: 1 object
fetching: 1 object
fetching: 1 object
fetching: 9 objects
fetching: 1 object
fetching: 1 object
fetching: 1 object
fetching: 1 object
fetching: 1 object
fetching: 1 object
fetching: 1 object
fetching: 1 object
fetching: 1 object
fetching: 1 object
fetching: 3 objects
fetching: 1 object
fetching: 1 object
fetching: 1 object
fetching: 1 object
fetching: 5 objects
fetching: 1 object
fetching: 1 object
fetching: 1 object
fetching: 1 object
fetching: 1 object
fetching: 1 object
fetching: 1 object
fetching: 1 object
fetching: 1 object
fetching: 1 object
fetching: 1 object
fetching: 1 object
fetching: 1 object
fetching: 1 object
fetching: 1 object
fetching: 1 object
fetching: 1 object
fetching: 1 object
fetching: 1 object
fetching: 1 object
fetching: 1 object
fetching: 1 object
fetching: 1 object
fetching: 1 object
fetching: 1 object
fetching: 1 object
fetching: 1 object
fetching: 1 object
fetching: 1 object
fetching: 1 object
fetching: 1 object
fetching: 1 object
fetching: 1 object
fetching: 1 object
including dependency: buffer (2.1.0)
including dependency: childprocess (2.1.1)
including dependency: codec (2.0.0)
including dependency: core (2.0.2)
including dependency: dgram (2.0.0)
including dependency: dns (2.0.4)
including dependency: fs (2.0.3)
including dependency: helpful (2.0.1)
including dependency: hooks (2.0.0)
including dependency: http (2.1.2)
including dependency: http-codec (2.0.2)
including dependency: http-header (1.0.0)
including dependency: https (2.0.0)
including dependency: json (2.5.2)
including dependency: los (2.0.0)
including dependency: net (2.0.2)
including dependency: path (2.0.1)
including dependency: pathjoin (2.0.0)
including dependency: pretty-print (2.0.1)
including dependency: process (2.1.0)
including dependency: querystring (2.0.1)
including dependency: readline (2.2.0)
including dependency: repl (2.1.3)
including dependency: require (2.2.1)
including dependency: resource (2.1.0)
including dependency: stream (2.0.1)
including dependency: thread (2.1.0)
including dependency: timer (2.0.1)
including dependency: tls (2.2.0)
including dependency: url (2.1.2)
including dependency: ustring (2.0.2)
including dependency: utils (2.0.0)
creating binary: C:\Users\Ryan\Programming\Luvit\lit\luvit.exe
using luvi from: C:\Users\Ryan\Programming\Luvit\lit\luvi.exe
inserting luvi: C:\Users\Ryan\Programming\Luvit\lit\luvi.exe
compiling: deps/buffer.lua (16.5% reduction)
compiling: deps/childprocess.lua (19.1% reduction)
compiling: deps/codec.lua (35.3% reduction)
compiling: deps/core.lua (57.3% reduction)
compiling: deps/dgram.lua (25.5% reduction)
compiling: deps/dns.lua (25.1% reduction)
compiling: deps/fs.lua (6.2% reduction)
compiling: deps/helpful.lua (42.7% reduction)
compiling: deps/hooks.lua (83.3% reduction)
compiling: deps/http-codec.lua (37.4% reduction)
compiling: deps/http-header.lua (59.4% reduction)
compiling: deps/http.lua (29.6% reduction)
compiling: deps/https.lua (45.6% reduction)
compiling: deps/json.lua (30.7% reduction)
compiling: deps/los.lua (76.9% reduction)
compiling: deps/net.lua (14.1% reduction)
compiling: deps/path/base.lua (24.9% reduction)
compiling: deps/path/init.lua (49.7% reduction)
storing: deps/path/package.lua
compiling: deps/pathjoin.lua (33.5% reduction)
compiling: deps/pretty-print.lua (30.6% reduction)
compiling: deps/process.lua (24.2% reduction)
compiling: deps/querystring.lua (35.9% reduction)
compiling: deps/readline.lua (18.6% reduction)
compiling: deps/repl.lua (28.2% reduction)
compiling: deps/require.lua (24.6% reduction)
compiling: deps/resource.lua (31.5% reduction)
compiling: deps/stream/init.lua (55.6% reduction)
storing: deps/stream/package.lua
compiling: deps/stream/stream_core.lua (38.5% reduction)
compiling: deps/stream/stream_duplex.lua (49.7% reduction)
compiling: deps/stream/stream_observable.lua (50.8% reduction)
compiling: deps/stream/stream_passthrough.lua (65.3% reduction)
compiling: deps/stream/stream_readable.lua (48.1% reduction)
compiling: deps/stream/stream_transform.lua (62% reduction)
compiling: deps/stream/stream_writable.lua (43% reduction)
compiling: deps/thread.lua (38.6% reduction)
compiling: deps/timer.lua (23.5% reduction)
compiling: deps/tls/common.lua (14.9% reduction)
compiling: deps/tls/init.lua (24.3% reduction)
compiling: deps/tls/lcrypto.lua (46.8% reduction)
compiling: deps/tls/package.lua (2.6% reduction)
compiling: deps/url.lua (32.8% reduction)
compiling: deps/ustring.lua (37.5% reduction)
compiling: deps/utils.lua (39.7% reduction)
compiling: init.lua (43% reduction)
compiling: main.lua (21.6% reduction)
compiling: package.lua (21.1% reduction)
done building: C:\Users\Ryan\Programming\Luvit\lit\luvit.exe
done: success
```