### PR TITLE
Make server fall back to resolving deps for missing snapshots when exporting zips

### DIFF
--- a/libs/api.lua
+++ b/libs/api.lua
@@ -274,12 +274,23 @@ return function (db, prefix)
       end
 
       -- Use snapshot if there is one
+      local snapshotExists = false
       if meta.snapshot then
-        hash = meta.snapshot
-      else
+        snapshotExists = pcall(function() db.loadAny(meta.snapshot) end)
+        if snapshotExists then
+          hash = meta.snapshot
+        end
+      end
+
+      if not snapshotExists then
         local deps = {}
         calculateDeps(db, deps, meta.dependencies)
         hash = installDeps(db, hash, deps)
+      end
+
+      -- Make sure the resolved snapshot hash matches
+      if not snapshotExists then
+        assert(hash == meta.snapshot, "Snapshot missing and resolved snapshot hash differs from existing hash (hash="..meta.snapshot..", resolved="..hash..")")
       end
 
       local zip = exportZip(db, hash)


### PR DESCRIPTION
Server-side version of #249 / 5c75c68a0e9836a96e9ba93a881121c4733e0dcf

Fixes #248 and most of #247 without needing the lit client to be updated

---

Also made it enforce that the resolved hash matches the hash in meta.snapshot, which means that its guaranteed that the next time the zip is requested it'll be able to just use the snapshot hash and not need to resolve the deps (since the resolution will create that hash in the db). Not sure if that makes sense to do or not.