### PR TITLE
Save snapshots as tags so they don't get deleted by git gc

### DIFF
--- a/libs/db.lua
+++ b/libs/db.lua
@@ -78,16 +78,20 @@ return function (rootPath)
     return match, assert(db.read(author, name, match))
   end
 
-  function db.read(author, name, version)
+  function db.tagRef(author, name, version, isSnapshot)
     version = normalize(version)
-    local ref = string.format("refs/tags/%s/%s/v%s", author, name, version)
+    local refDir = isSnapshot and "snapshots" or "tags"
+    return string.format("refs/%s/%s/%s/v%s", refDir, author, name, version)
+  end
+
+  function db.read(author, name, version, isSnapshot)
+    local ref = db.tagRef(author, name, version, isSnapshot)
     return db.getRef(ref)
   end
 
-  function db.write(author, name, version, hash)
-    version = normalize(version)
+  function db.write(author, name, version, hash, isSnapshot)
     assertHash(hash)
-    local ref = string.format("refs/tags/%s/%s/v%s", author, name, version)
+    local ref = db.tagRef(author, name, version, isSnapshot)
     storage.write(ref, hash .. "\n")
   end
 


### PR DESCRIPTION
Creates a new tag for each snapshot hash at `refs/snapshots/<author>/<name>/v<version>` with the tag name `snapshots/<author>/<name>/v<version>`. The tag ref is created outside of `refs/tags` so that other methods that iterate the refs don't include snapshots in their iterations (i.e. db.authors() simply returns all nodes in `refs/tags`). It's confirmed that the tag being in `refs/snapshots` still makes it exempt from `git gc`: without the tag, `git gc --prune=all` prunes the snapshot hash, but with the tag it remains after `git gc --prune=all`.

Note: This is an incomplete implementation; it only creates the snapshot tag in `lit add`, not on the server during `lit publish` (or any other places where it might also need to be created)

---

I feel like I'm getting a bit over my head with this, since I'm not super familiar with the db structure/lit internals/git internals/etc, so I thought I'd push the bit that I've got so far for feedback. As far as I can tell, what needs to be done to finish this up is evaluate/update the other instances of `db.write` throughout the code ([rdb.lua](https://github.com/luvit/lit/blob/85355d57a791052e6c7cb67a94b6dee5133aba9a/libs/rdb.lua#L212), [handlers.lua](https://github.com/luvit/lit/blob/85355d57a791052e6c7cb67a94b6dee5133aba9a/libs/handlers.lua#L148)) to also create the snapshot tag.