### PR TITLE
get-lit: Allow specifiying the lit/luvi versions to download

### DIFF
--- a/get-lit.ps1
+++ b/get-lit.ps1
@@ -1,6 +1,9 @@
 
 $LUVI_VERSION = "2.9.3"
 $LIT_VERSION = "3.7.3"
+# Environment variables take precedence
+if (test-path env:LUVI_VERSION) { $LUVI_VERSION = $env:LUVI_VERSION }
+if (test-path env:LIT_VERSION) { $LIT_VERSION = $env:LIT_VERSION }
 
 if (test-path env:LUVI_ARCH) {
   $LUVI_ARCH = $env:LUVI_ARCH

--- a/get-lit.sh
+++ b/get-lit.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -eu
-LUVI_VERSION=2.9.3
-LIT_VERSION=3.7.3
+LUVI_VERSION=${LUVI_VERSION:-2.9.3}
+LIT_VERSION=${LIT_VERSION:-3.7.3}
 
 LUVI_ARCH=`uname -s`_`uname -m`
 LUVI_URL="https://github.com/luvit/luvi/releases/download/v$LUVI_VERSION/luvi-regular-$LUVI_ARCH"


### PR DESCRIPTION
Example sh usage:

`curl get-lit.sh | LUVI_VERSION=2.7.6 LIT_VERSION=3.5.4 sh`

Example ps1 usage:

```
set LUVI_VERSION=3.5.4
set LIT_VERSION=2.7.6
PowerShell -NoProfile ...
```

---

Note that it would also be possible to specify the Luvit version (to do something like `lit make lit://luvit/luvit@2.11.2`), but due to how the Lit version matching works, this will match `2.x.x` so it wouldn't really be useful (i.e. it would install `2.15.0` even if you specify `2.11.2`).