### PR TITLE
Bump deps / Luvi / Lit versions

### DIFF
--- a/deps/http-codec.lua
+++ b/deps/http-codec.lua
@@ -18,7 +18,7 @@ limitations under the License.
 
 --[[lit-meta
   name = "luvit/http-codec"
-  version = "3.0.4"
+  version = "3.0.5"
   homepage = "https://github.com/luvit/luvit/blob/master/deps/http-codec.lua"
   description = "A simple pair of functions for converting between hex and raw strings."
   tags = {"codec", "http"}

--- a/get-lit.ps1
+++ b/get-lit.ps1
@@ -1,6 +1,6 @@
 
 $LUVI_VERSION = "2.10.1"
-$LIT_VERSION = "3.7.3"
+$LIT_VERSION = "3.8.0"
 # Environment variables take precedence
 if (test-path env:LUVI_VERSION) { $LUVI_VERSION = $env:LUVI_VERSION }
 if (test-path env:LIT_VERSION) { $LIT_VERSION = $env:LIT_VERSION }

--- a/get-lit.ps1
+++ b/get-lit.ps1
@@ -1,5 +1,5 @@
 
-$LUVI_VERSION = "2.9.3"
+$LUVI_VERSION = "2.10.1"
 $LIT_VERSION = "3.7.3"
 # Environment variables take precedence
 if (test-path env:LUVI_VERSION) { $LUVI_VERSION = $env:LUVI_VERSION }

--- a/get-lit.sh
+++ b/get-lit.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -eu
 LUVI_VERSION=${LUVI_VERSION:-2.10.1}
-LIT_VERSION=${LIT_VERSION:-3.7.3}
+LIT_VERSION=${LIT_VERSION:-3.8.0}
 
 LUVI_ARCH=`uname -s`_`uname -m`
 LUVI_URL="https://github.com/luvit/luvi/releases/download/v$LUVI_VERSION/luvi-regular-$LUVI_ARCH"

--- a/get-lit.sh
+++ b/get-lit.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 set -eu
-LUVI_VERSION=${LUVI_VERSION:-2.9.3}
+LUVI_VERSION=${LUVI_VERSION:-2.10.1}
 LIT_VERSION=${LIT_VERSION:-3.7.3}
 
 LUVI_ARCH=`uname -s`_`uname -m`

--- a/package.lua
+++ b/package.lua
@@ -7,7 +7,7 @@ return {
   license = "Apache 2",
   author = { name = "Tim Caswell" },
   luvi = {
-    version = "v2.9.3",
+    version = "v2.10.1",
     flavor = "regular",
   },
   dependencies = {

--- a/package.lua
+++ b/package.lua
@@ -1,6 +1,6 @@
 return {
   name = "luvit/lit",
-  version = "3.7.3",
+  version = "3.8.0",
   homepage = "https://github.com/luvit/lit",
   description = "The Luvit Invention Toolkit is a luvi app that handles dependencies and luvi builds.",
   tags = {"lit", "meta"},
@@ -12,7 +12,7 @@ return {
   },
   dependencies = {
     "luvit/pretty-print@2.0.1",
-    "luvit/http-codec@3.0.4",
+    "luvit/http-codec@3.0.5",
     "luvit/json@2.5.2",
     "luvit/resource@2.1.0",
     "luvit/secure-socket@1.2.2",


### PR DESCRIPTION
Note that, as of now, the latest version of `creationix/coro-fs` has not been published (https://github.com/luvit/lit/pull/260). Because it's not in the `luvit/` namespace, I believe only @creationix can do that. Might be worth waiting for that to be published before merging this.

Closes #265 