### PR TITLE
api: Do more caching to speed up search responses

### DIFF
--- a/commands/serve.lua
+++ b/commands/serve.lua
@@ -5,9 +5,12 @@ return function ()
   local log = require('log').log
   local makeRemote = require('codec').makeRemote
   local core = require('core')()
+  local cachedDb = require('db-cached')
 
   local handlers = require('handlers')(core)
-  local handleRequest = require('api')(core.db, args[2])
+  -- use cached db
+  local db = cachedDb(core.db)
+  local handleRequest = require('api')(db, args[2])
 
   local app = require('weblit-app')
   require 'weblit-websocket'

--- a/libs/api.lua
+++ b/libs/api.lua
@@ -468,6 +468,10 @@ return function (db, prefix)
           end
         end
       end
+      -- update all urls to use the current prefix
+      for match, meta in pairs(matches) do
+        meta.url = (prefix or '') .. urlCache[meta]
+      end
       local res = {
         query = query,
         matches = matches,
@@ -523,10 +527,6 @@ return function (db, prefix)
       end
     end
     if type(body) == "table" then
-      -- update all urls to use the current prefix
-      for match, meta in pairs(body.matches) do
-        meta.url = (prefix or '') .. urlCache[meta]
-      end
       body = jsonStringify(body) .. "\n"
       res.headers["Content-Type"] = "application/json"
     end

--- a/libs/api.lua
+++ b/libs/api.lua
@@ -83,7 +83,6 @@ local installDeps = require('install-deps').toDb
 local ffi = require('ffi')
 local fs = require('coro-fs')
 local metrics = require('metrics')
-local cachedDb = require('db-cached')
 local uv = require('uv')
 
 local function hex_to_char(x)
@@ -235,9 +234,6 @@ return function (db, prefix)
     return meta
   end
 
-  -- use cached db
-  db = cachedDb(db)
-
   local timeStart, memStart = uv.now(), collectgarbage("count")
   -- warm up db cache and meta cache
   for author in db.authors() do
@@ -245,7 +241,7 @@ return function (db, prefix)
       local _ = loadMeta(author, name)
     end
   end
-  print('cache warmed in ' .. (uv.now() - timeStart) .. 'ms, using ' .. string.format("%0.2f", (collectgarbage("count") - memStart) / 1024) .. ' MB memory')
+  print('api cache warmed in ' .. (uv.now() - timeStart) .. 'ms, using ' .. string.format("%0.2f", (collectgarbage("count") - memStart) / 1024) .. ' MB memory')
 
   local routes = {
     "^/metrics$", collectStats,

--- a/libs/db-cached.lua
+++ b/libs/db-cached.lua
@@ -1,0 +1,95 @@
+--[[
+
+Copyright 2014-2015 The Luvit Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS-IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+--]]
+
+-- like ipairs but omits the index var
+local function viter(tbl)
+  local i = 0
+  return function()
+    i = i + 1
+    return tbl[i]
+  end
+end
+
+-- populate a cache table of values from a viter-type iterator
+local function vcache(cache, iter)
+  for v in iter do
+    table.insert(cache, v)
+  end
+  return cache
+end
+
+return function (db)
+  local semver = require('semver')
+  local normalize = semver.normalize
+
+  db.cache = {}
+
+  db.uncachedRead = db.read
+  db.cache.refs = {}
+  function db.read(author, name, version)
+    version = normalize(version)
+    local ref = string.format("refs/tags/%s/%s/v%s", author, name, version)
+    if not db.cache.refs[ref] then
+      db.cache.refs[ref] = db.uncachedRead(author, name, version)
+    end
+    return db.cache.refs[ref]
+  end
+
+  local doWrite = db.write
+  function db.write(author, name, version, hash)
+    doWrite(author, name, version, hash)
+
+    -- update relevant caches
+    db.cache.authors = vcache({}, db.uncachedAuthors())
+    db.cache.names[author] = vcache({}, db.uncachedNames(author))
+    db.cache.versions[author] = db.cache.versions[author] or {}
+    db.cache.versions[author][name] = vcache({}, db.uncachedVersions(author, name))
+  end
+
+  db.uncachedAuthors = db.authors
+  db.cache.authors = nil
+  function db.authors()
+    if not db.cache.authors then
+      db.cache.authors = vcache({}, db.uncachedAuthors())
+    end
+    return viter(db.cache.authors)
+  end
+
+  db.uncachedNames = db.names
+  db.cache.names = {}
+  function db.names(author)
+    if not db.cache.names[author] then
+      db.cache.names[author] = vcache({}, db.uncachedNames(author))
+    end
+    return viter(db.cache.names[author])
+  end
+
+  db.uncachedVersions = db.versions
+  db.cache.versions = {}
+  function db.versions(author, name)
+    if not db.cache.versions[author] then
+      db.cache.versions[author] = {}
+    end
+    if not db.cache.versions[author][name] then
+      db.cache.versions[author][name] = vcache({}, db.uncachedVersions(author, name))
+    end
+    return viter(db.cache.versions[author][name])
+  end
+
+  return db
+end


### PR DESCRIPTION
Should help with https://github.com/luvit/luvit.io/issues/24

There are two parts to this:

- The API was already caching the `hash -> meta` part of the `author/name/version -> hash -> meta` lookup, but this cache was not being warmed on start, so the first request would take roughly twice as long as future requests.
  + Warming the cache in advance also required a change to how urls were cached, since its technically possible for `prefix` to change between requests, so we can't use the same cached url every time
- All db lookups would access the file system every time, meaning that all `/search/` endpoint requests would iterate all refs, read them, etc for general searches i.e. `/search/*`. The actual values very rarely change, though, and the amount of memory needed to cache all those lookups is rather small (~1.5MB for lit-backup.git), so we can cache them and just invalidate the cache when a new ref is added via `db.write`.
  + This cache is also warmed at the same time as the `hash -> meta` one

Performance numbers for `/search/*`:

Before:
```
request 1 handled in 402ms, body length = 182518
request 2 handled in 209ms, body length = 182518
request 3 handled in 216ms, body length = 182518
request 4 handled in 206ms, body length = 182518
request 5 handled in 205ms, body length = 182518
```

After:
```
cache warmed in 444ms, using 1.52 MB memory
request 1 handled in 22ms, body length = 182518
request 2 handled in 21ms, body length = 182518
request 3 handled in 18ms, body length = 182518
request 4 handled in 19ms, body length = 182518
request 5 handled in 18ms, body length = 182518
```

(almost all the time for `/search/*` is now spent in `json.stringify`)

---

This is currently a draft because I haven't tested the cache invalidation part of it yet (`db.write`), and am not positive that `db.write` is the only pathway to modifying the cached data (if other `db` functions could modify the cached data, then the cache would not be updated, leading to the lit api responses being out-of-sync with the actual state of the db).