### PR TITLE
get-lit.ps1: Specify the current directory when starting luvi.exe/lit.exe

### DIFF
--- a/get-lit.ps1
+++ b/get-lit.ps1
@@ -34,8 +34,8 @@ Download-File $LUVI_URL "luvi.exe"
 Download-File $LIT_URL "lit.zip"
 
 # Create lit.exe using lit
-Start-Process "luvi.exe" -ArgumentList "lit.zip -- make lit.zip lit.exe luvi.exe" -Wait -NoNewWindow
+Start-Process ".\luvi.exe" -ArgumentList "lit.zip -- make lit.zip lit.exe luvi.exe" -Wait -NoNewWindow
 # Cleanup
 Remove-Item "lit.zip"
 # Create luvit using lit
-Start-Process "lit.exe" -ArgumentList "make lit://luvit/luvit luvit.exe luvi.exe" -Wait -NoNewWindow
+Start-Process ".\lit.exe" -ArgumentList "make lit://luvit/luvit luvit.exe luvi.exe" -Wait -NoNewWindow


### PR DESCRIPTION
If there was an older lit.exe or luvi.exe on your PATH, then running get-lit.ps1 anywhere would use those older existing lit.exe/luvi.exe instead of the newly downloaded ones. This could lead to 'cannot load incompatible bytecode' errors that should no longer be possible after #263.