### PR TITLE
Handle timeout requests

### DIFF
--- a/deps/coro-http.lua
+++ b/deps/coro-http.lua
@@ -105,8 +105,11 @@ end
 local function request(method, url, headers, body, timeout)
   local uri = parseUrl(url)
   local connection = getConnection(uri.hostname, uri.port, uri.tls, timeout)
-  local read = connection.read
   local write = connection.write
+  if write == "timeout" then
+    return nil, write
+  end
+  local read = connection.read
 
   local req = {
     method = method,


### PR DESCRIPTION
When you set a timeout value in `coro-http`.`request`, it can happen that the returned value for `write` is a string `"timeout"`, and it ends up breaking in `write(req)`.

Now, it returns a `nil` header with body `"timeout"`.

Refers to
```
Uncaught Error: .../deps/coro-http.lua:137: attempt to call local 'write' (a string value)
```
May be helpful for https://github.com/luvit/lit/issues/216