### PR TITLE
Fix secure-socket for OpenSSL 1.1.0

### DIFF
--- a/deps/secure-socket/context.lua
+++ b/deps/secure-socket/context.lua
@@ -33,7 +33,7 @@ do
   local isLibreSSL = V:find('^LibreSSL')
 
   _, _, V = openssl.version(true)
-  local isTLSv1_3 = not isLibreSSL and V > 0x10100000
+  local isTLSv1_3 = not isLibreSSL and V > 0x10101000
 
   if isTLSv1_3 then
     DEFAULT_SECUREPROTOCOL = 'TLS'

--- a/deps/secure-socket/context.lua
+++ b/deps/secure-socket/context.lua
@@ -33,7 +33,7 @@ do
   local isLibreSSL = V:find('^LibreSSL')
 
   _, _, V = openssl.version(true)
-  local isTLSv1_3 = not isLibreSSL and V > 0x10101000
+  local isTLSv1_3 = not isLibreSSL and V >= 0x10101000
 
   if isTLSv1_3 then
     DEFAULT_SECUREPROTOCOL = 'TLS'


### PR DESCRIPTION
The fix in #257 makes DEFAULT_SECUREPROTOCOL `TLS` on OpenSSL 1.1.0, which does not support it (it correctly does this for OpenSSL < 1.1.0 and OpenSSL > 1.1.0). This specific OpenSSL version does not accept `TLS` and should instead use `SSLv23` like previous versions.

This issue keeps coming up with people using Luvi 2.9.1 (the affected luvi).