### PR TITLE
Assert pkey.read for better error messages when failing to parse privateKey file

### DIFF
--- a/libs/core.lua
+++ b/libs/core.lua
@@ -113,7 +113,7 @@ local function makeCore(config)
     if not config.privateKey then return end
     if privateKey then return privateKey end
     local keyData = assert(gfs.readFile(config.privateKey))
-    privateKey = require('openssl').pkey.read(keyData, true)
+    privateKey = assert(require('openssl').pkey.read(keyData, true))
     return privateKey
   end
 


### PR DESCRIPTION
Helps with debugging #261