### PR TITLE
Preserves tracebacks  for coroutine resumes

### DIFF
--- a/deps/coro-channel.lua
+++ b/deps/coro-channel.lua
@@ -10,6 +10,13 @@
 
 -- local p = require('pretty-print').prettyPrint
 
+local function assertResume(thread, ...)
+  local success, err = coroutine.resume(thread, ...)
+  if not success then
+    error(debug.traceback(thread, err), 0)
+  end
+end
+
 local function makeCloser(socket)
   local closer = {
     read = false,
@@ -59,7 +66,7 @@ local function makeRead(socket, closer)
       local thread = queue[dindex]
       queue[dindex] = nil
       dindex = dindex + 1
-      assert(coroutine.resume(thread, unpack(data)))
+      assertResume(thread, unpack(data))
     else
       queue[dindex] = data
       dindex = dindex + 1
@@ -116,7 +123,7 @@ local function makeWrite(socket, closer)
   local function wait()
     local thread = coroutine.running()
     return function (err)
-      assert(coroutine.resume(thread, err))
+      assertResume(thread, err)
     end
   end
 

--- a/deps/coro-channel.lua
+++ b/deps/coro-channel.lua
@@ -1,6 +1,6 @@
 --[[lit-meta
   name = "creationix/coro-channel"
-  version = "3.0.1"
+  version = "3.0.2"
   homepage = "https://github.com/luvit/lit/blob/master/deps/coro-channel.lua"
   description = "An adapter for wrapping uv streams as coro-streams."
   tags = {"coro", "adapter"}

--- a/deps/coro-fs.lua
+++ b/deps/coro-fs.lua
@@ -16,15 +16,22 @@ local uv = require('uv')
 local fs = {}
 local pathJoin = require('pathjoin').pathJoin
 
+local function assertResume(thread, ...)
+  local success, err = coroutine.resume(thread, ...)
+  if not success then
+    error(debug.traceback(thread, err), 0)
+  end
+end
+
 local function noop() end
 
 local function makeCallback()
   local thread = coroutine.running()
   return function (err, value, ...)
     if err then
-      assert(coroutine.resume(thread, nil, err))
+      assertResume(thread, nil, err)
     else
-      assert(coroutine.resume(thread, value == nil and true or value, ...))
+      assertResume(thread, value == nil and true or value, ...)
     end
   end
 end

--- a/deps/coro-fs.lua
+++ b/deps/coro-fs.lua
@@ -1,6 +1,6 @@
 --[[lit-meta
   name = "creationix/coro-fs"
-  version = "2.2.3"
+  version = "2.2.4"
   homepage = "https://github.com/luvit/lit/blob/master/deps/coro-fs.lua"
   description = "A coro style interface to the filesystem."
   tags = {"coro", "fs"}

--- a/deps/coro-net.lua
+++ b/deps/coro-net.lua
@@ -1,6 +1,6 @@
 --[[lit-meta
   name = "creationix/coro-net"
-  version = "3.2.0"
+  version = "3.2.1"
   dependencies = {
     "creationix/coro-channel@3.0.0",
     "creationix/coro-wrapper@3.0.0",

--- a/deps/coro-net.lua
+++ b/deps/coro-net.lua
@@ -23,6 +23,13 @@ local decoder = wrapper.decoder
 local encoder = wrapper.encoder
 local secureSocket -- Lazy required from "secure-socket" on first use.
 
+local function assertResume(thread, ...)
+  local success, err = coroutine.resume(thread, ...)
+  if not success then
+    error(debug.traceback(thread, err), 0)
+  end
+end
+
 local function makeCallback(timeout)
   local thread = coroutine.running()
   local timer, done
@@ -32,7 +39,7 @@ local function makeCallback(timeout)
       if done then return end
       done = true
       timer:close()
-      return assert(coroutine.resume(thread, nil, "timeout"))
+      return assertResume(thread, nil, "timeout")
     end)
   end
   return function (err, data)
@@ -40,9 +47,9 @@ local function makeCallback(timeout)
     done = true
     if timer then timer:close() end
     if err then
-      return assert(coroutine.resume(thread, nil, err))
+      return assertResume(thread, nil, err)
     end
-    return assert(coroutine.resume(thread, data or true))
+    return assertResume(thread, data or true)
   end
 end
 

--- a/deps/coro-spawn.lua
+++ b/deps/coro-spawn.lua
@@ -1,6 +1,6 @@
 --[[lit-meta
   name = "creationix/coro-spawn"
-  version = "3.0.1"
+  version = "3.0.2"
   dependencies = {
     "creationix/coro-channel@3.0.0"
   }

--- a/deps/coro-spawn.lua
+++ b/deps/coro-spawn.lua
@@ -16,6 +16,13 @@ local channel = require('coro-channel')
 local wrapRead = channel.wrapRead
 local wrapWrite = channel.wrapWrite
 
+local function assertResume(thread, ...)
+  local success, err = coroutine.resume(thread, ...)
+  if not success then
+    error(debug.traceback(thread, err), 0)
+  end
+end
+
 return function (path, options)
   local stdin, stdout, stderr
   local stdio = options.stdio
@@ -49,7 +56,7 @@ return function (path, options)
     if not exitThread then return end
     local thread = exitThread
     exitThread = nil
-    return assert(coroutine.resume(thread, code, signal))
+    return assertResume(thread, code, signal)
   end
 
   local handle, pid = uv.spawn(path, options, onExit)

--- a/deps/coro-split.lua
+++ b/deps/coro-split.lua
@@ -12,6 +12,13 @@
 -- The split function will itself block and wait for all three to finish.
 -- The results of the functions will be returned from split.
 
+local function assertResume(thread, ...)
+  local success, err = coroutine.resume(thread, ...)
+  if not success then
+    error(debug.traceback(thread, err), 0)
+  end
+end
+
 return function (...)
   local tasks = {...}
   for i = 1, #tasks do
@@ -23,7 +30,7 @@ return function (...)
   local function check()
     left = left - 1
     if left == 0 then
-      assert(coroutine.resume(thread, unpack(results)))
+      assertResume(thread, unpack(results))
     end
   end
   for i = 1, #tasks do

--- a/deps/coro-split.lua
+++ b/deps/coro-split.lua
@@ -1,6 +1,6 @@
 --[[lit-meta
   name = "creationix/coro-split"
-  version = "2.0.0"
+  version = "2.0.1"
   homepage = "https://github.com/luvit/lit/blob/master/deps/coro-split.lua"
   description = "An coro style helper for running tasks concurrently."
   tags = {"coro", "split"}

--- a/deps/prompt.lua
+++ b/deps/prompt.lua
@@ -13,6 +13,13 @@
 
 local readLine = require('readline').readLine
 
+local function assertResume(thread, ...)
+  local success, err = coroutine.resume(thread, ...)
+  if not success then
+    error(debug.traceback(thread, err), 0)
+  end
+end
+
 return function (options)
   -- Wrapper around readline to provide a nice blocking version for coroutines
   return function (message, default)
@@ -27,9 +34,9 @@ return function (options)
     repeat
       readLine(message, options, function (err, line, reason)
         if err then
-          return assert(coroutine.resume(thread, nil, err))
+          return assertResume(thread, nil, err)
         end
-        return assert(coroutine.resume(thread, line, reason))
+        return assertResume(thread, line, reason)
       end)
       value = assert(coroutine.yield())
       if default and #value == 0 then

--- a/deps/prompt.lua
+++ b/deps/prompt.lua
@@ -1,6 +1,6 @@
 --[[lit-meta
   name = "creationix/prompt"
-  version = "2.0.0"
+  version = "2.0.1"
   dependencies = {
     "luvit/readline@2.0.0"
   }

--- a/deps/secure-socket/init.lua
+++ b/deps/secure-socket/init.lua
@@ -18,6 +18,13 @@ limitations under the License.
 local getContext = require('./context')
 local bioWrap = require('./biowrap')
 
+local function assertResume(thread, ...)
+  local success, err = coroutine.resume(thread, ...)
+  if not success then
+    error(debug.traceback(thread, err), 0)
+  end
+end
+
 return function (socket, options, callback)
   if options == true then options = {} end
   local ctx = getContext(options)
@@ -26,7 +33,7 @@ return function (socket, options, callback)
     thread = coroutine.running()
   end
   bioWrap(ctx, options.server, socket, callback or function (err, ssocket)
-    return assert(coroutine.resume(thread, ssocket, err))
+    return assertResume(thread, ssocket, err)
 end, options.servername)
   if not callback then
     return coroutine.yield()

--- a/deps/secure-socket/package.lua
+++ b/deps/secure-socket/package.lua
@@ -1,6 +1,6 @@
 return {
   name = "luvit/secure-socket",
-  version = "1.2.2",
+  version = "1.2.3",
   homepage = "https://github.com/luvit/luvit/blob/master/deps/secure-socket",
   description = "Wrapper for luv streams to apply ssl/tls",
   dependencies = {


### PR DESCRIPTION
Closes #273. 

I replaced every `assert(coroutine.resume(thread, ...))` with an `assertResume(thread, ...)` wrapper defined in each file that needs it. Not really a sustainable solution, but I didn't want to make a new dependency at this time.