### PR TITLE
coro-http: createServer: exposing the server handle

### DIFF
--- a/deps/coro-http.lua
+++ b/deps/coro-http.lua
@@ -16,7 +16,7 @@ local httpCodec = require('http-codec')
 local net = require('coro-net')
 
 local function createServer(host, port, onConnect)
-  net.createServer({
+  return net.createServer({
     host = host,
     port = port,
     encode = httpCodec.encoder(),


### PR DESCRIPTION
Since `coro_net.createServer` already exposes the server handle, wouldn't also make sense to do that on the `coro-http` side? So stuff such as closing the server (for example) can be done.