### PR TITLE
http-codec: decoder may use decodeRaw and never switch back

### DIFF
--- a/deps/http-codec.lua
+++ b/deps/http-codec.lua
@@ -18,7 +18,7 @@ limitations under the License.
 
 --[[lit-meta
   name = "luvit/http-codec"
-  version = "3.0.6"
+  version = "3.0.7"
   homepage = "https://github.com/luvit/luvit/blob/master/deps/http-codec.lua"
   description = "A simple pair of functions for converting between hex and raw strings."
   tags = {"codec", "http"}
@@ -241,7 +241,10 @@ local function decoder()
   end
 
   function decodeRaw(chunk, index)
-    if #chunk < index then return end
+    if #chunk < index then
+      mode = decodeHead
+      return
+    end
     return sub(chunk, index)
   end
 


### PR DESCRIPTION
One of my friends have been running into this problem for a while now, randomly their Weblit server would just freeze giving random errors, I have traced this all the way to http-codec and noticed that when decodeRaw is used, it never switches back, making __all__ requests after the said request return with a nil, providing `nil` to Weblit's `req.path` (using the wrapped reader that make use of http-codec decoder), which is expected to always exists, causing a nil value to be indexed.

To replicate the above bug you can use the following setup:
server.lua:
```lua
require('coro-http').createServer("127.0.0.1", 8080, function()
  return {code = 200, reason = "OK", {"Content-Length", "5"}}, "hello"
end)
```
A server that always responds with 200 - hello. Testing this alone would work just fine as expected.
Now send an HTTP request similar to this
```http
OPTIONS / HTTP/1.1
Connection: upgrade
accept-encoding: gzip
user-agent: curl/7.77.0
accept: */*
```
Any HTTP request that force the use of decodeRaw mode will do.

Now send any request you like, GET, POST, doesn't matter:
Expected behavior: The server returning 200 - hello response.
Current Behavior: The server completely freezes not responding to any other request (since it always use decodeRaw now)

This PR should fix this by changing to decodeHead mode when the chunk is consumed.