### PR TITLE
coro-http: properly close the socket

### DIFF
--- a/deps/coro-http.lua
+++ b/deps/coro-http.lua
@@ -35,9 +35,8 @@ local function createServer(host, port, onConnect)
       head, body = onConnect(head, body, socket)
       write(head)
       if body then write(body) end
-      write("")
+      write()
       if not head.keepAlive then
-        socket:close()
         break
       end
     end

--- a/deps/coro-http.lua
+++ b/deps/coro-http.lua
@@ -1,6 +1,6 @@
 --[[lit-meta
   name = "creationix/coro-http"
-  version = "3.2.0"
+  version = "3.2.1"
   dependencies = {
     "creationix/coro-net@3.0.0",
     "luvit/http-codec@3.0.0"
@@ -36,7 +36,10 @@ local function createServer(host, port, onConnect)
       write(head)
       if body then write(body) end
       write("")
-      if not head.keepAlive then break end
+      if not head.keepAlive then
+        socket:close()
+        break
+      end
     end
   end)
 end


### PR DESCRIPTION
Closes #274. Forcibly close the socket stream on connection death, that's, when keepAlive is false.

On my end, this seems to solve the CLOSE_WAIT issue when `netstat`ing and the handles seems to be completely closed.
I would argue this should actually go to coro-net not to coro-http, since that's more general and affects more stuff. Though I am not sure if any other libraries do in fact expect the handle to always stay there even on CLOSE_WAIT state, otherwise that would be a breaking change.