### PR TITLE
Add proper stateful codec support to coro-net.

### DIFF
--- a/deps/coro-http.lua
+++ b/deps/coro-http.lua
@@ -1,8 +1,8 @@
 --[[lit-meta
   name = "creationix/coro-http"
-  version = "3.2.0"
+  version = "3.2.1"
   dependencies = {
-    "creationix/coro-net@3.0.0",
+    "creationix/coro-net@3.3.0",
     "luvit/http-codec@3.0.0"
   }
   homepage = "https://github.com/luvit/lit/blob/master/deps/coro-http.lua"
@@ -19,8 +19,8 @@ local function createServer(host, port, onConnect)
   return net.createServer({
     host = host,
     port = port,
-    encode = httpCodec.encoder(),
-    decode = httpCodec.decoder(),
+    encoder = httpCodec.encoder,
+    decoder = httpCodec.decoder,
   }, function (read, write, socket)
     for head in read do
       local parts = {}
@@ -76,8 +76,8 @@ local function getConnection(host, port, tls, timeout)
     port = port,
     tls = tls,
     timeout = timeout,
-    encode = httpCodec.encoder(),
-    decode = httpCodec.decoder()
+    encoder = httpCodec.encoder,
+    decoder = httpCodec.decoder
   })
   return {
     socket = socket,

--- a/deps/coro-net.lua
+++ b/deps/coro-net.lua
@@ -1,6 +1,6 @@
 --[[lit-meta
   name = "creationix/coro-net"
-  version = "3.2.1"
+  version = "3.3.0"
   dependencies = {
     "creationix/coro-channel@3.0.0",
     "creationix/coro-wrapper@3.0.0",
@@ -124,10 +124,14 @@ local function connect(options)
     -- TODO: Should we expose updateScan somehow?
     read = merger(read, options.scan)
   end
-  if options.decode then
+  if options.decoder then
+    read, updateDecoder = decoder(read, options.decoder())
+  elseif options.decode then
     read, updateDecoder = decoder(read, options.decode)
   end
-  if options.encode then
+  if options.encoder then
+    write, updateEncoder = encoder(write, options.encoder())
+  elseif options.encode then
     write, updateEncoder = encoder(write, options.encode)
   end
   return read, write, dsocket, updateDecoder, updateEncoder, close
@@ -164,10 +168,14 @@ local function createServer(options, onConnect)
           -- TODO: should we expose updateScan somehow?
           read = merger(read, options.scan)
         end
-        if options.decode then
+        if options.decoder then
+          read, updateDecoder = decoder(read, options.decoder())
+        elseif options.decode then
           read, updateDecoder = decoder(read, options.decode)
         end
-        if options.encode then
+        if options.encoder then
+          write, updateEncoder = encoder(write, options.encoder())
+        elseif options.encode then
           write, updateEncoder = encoder(write, options.encode)
         end
 

--- a/deps/coro-websocket.lua
+++ b/deps/coro-websocket.lua
@@ -1,10 +1,10 @@
 --[[lit-meta
   name = "creationix/coro-websocket"
-  version = "3.1.0"
+  version = "3.1.1"
   dependencies = {
     "luvit/http-codec@3.0.0",
     "creationix/websocket-codec@3.0.0",
-    "creationix/coro-net@3.0.0",
+    "creationix/coro-net@3.3.0",
   }
   homepage = "https://github.com/luvit/lit/blob/master/deps/coro-websocket.lua"
   description = "Websocket helpers assuming coro style I/O."
@@ -139,8 +139,8 @@ local function connect(options)
     host = options.host,
     port = options.port,
     tls = options.tls,
-    encode = httpCodec.encoder(),
-    decode = httpCodec.decoder(),
+    encoder = httpCodec.encoder,
+    decoder = httpCodec.decoder,
   }
   local read, write, socket, updateDecoder, updateEncoder
     = net.connect(config, options.timeout or 10000)

--- a/deps/weblit-server.lua
+++ b/deps/weblit-server.lua
@@ -1,8 +1,8 @@
 --[[lit-meta
   name = "creationix/weblit-server"
-  version = "3.1.2"
+  version = "3.1.3"
   dependencies = {
-    'creationix/coro-net@3.0.0',
+    'creationix/coro-net@3.3.0',
     'luvit/http-codec@3.0.0'
   }
   description = "Weblit is a webapp framework designed around routes and middleware layers."
@@ -189,8 +189,8 @@ local function newServer(run)
     for addr, options in pairs(ips) do
       local host, port = addr:match("(.*) (.*)")
       port = tonumber(port)
-      options.decode = httpCodec.decoder()
-      options.encode = httpCodec.encoder()
+      options.decoder = httpCodec.decoder
+      options.encoder = httpCodec.encoder
       options.host = host
       options.port = port
       createServer(options, handleConnection)

--- a/libs/rdb.lua
+++ b/libs/rdb.lua
@@ -45,8 +45,8 @@ local function connectRemote(url, timeout)
     host = host,
     port = port,
     tls = tls,
-    encode = httpCodec.encoder(),
-    decode = httpCodec.decoder(),
+    encoder = httpCodec.encoder,
+    decoder = httpCodec.decoder,
   }, timeout))
 
   -- Perform the websocket handshake

--- a/package.lua
+++ b/package.lua
@@ -1,6 +1,6 @@
 return {
   name = "luvit/lit",
-  version = "3.8.2",
+  version = "3.8.3",
   homepage = "https://github.com/luvit/lit",
   description = "The Luvit Invention Toolkit is a luvi app that handles dependencies and luvi builds.",
   tags = {"lit", "meta"},
@@ -17,7 +17,7 @@ return {
     "luvit/resource@2.1.0",
     "luvit/secure-socket@1.2.2",
     "creationix/coro-fs@2.2.2",
-    "creationix/coro-net@3.2.0",
+    "creationix/coro-net@3.3.0",
     "creationix/coro-http@3.1.0",
     "creationix/coro-wrapper@3.1.0",
     "creationix/coro-spawn@3.0.1",


### PR DESCRIPTION
http-codec is a stateful parser and this wasn't really supported properly.
Before this patch, coro-net would reuse the exact same stateful parser
for all concurrent and future streams which has many issues.

This was probably the cause of many bugs including the one that makes
the production website hang whenever a request triggers http raw body mode.

This PR updates coro-net to now support both statefull and stateless codecs
and updates coro-http, coro-websocket and others to use the new feature.

Third-party libraries that use coro-net directly with http-codec will need
a similar update.