### PR TITLE
Fix coro-http server to close the socket when done

### DIFF
--- a/deps/coro-channel.lua
+++ b/deps/coro-channel.lua
@@ -1,6 +1,6 @@
 --[[lit-meta
   name = "creationix/coro-channel"
-  version = "3.0.2"
+  version = "3.0.3"
   homepage = "https://github.com/luvit/lit/blob/master/deps/coro-channel.lua"
   description = "An adapter for wrapping uv streams as coro-streams."
   tags = {"coro", "adapter"}
@@ -139,8 +139,6 @@ local function makeWrite(socket, closer)
       closer.check()
       local success, err = socket:shutdown(wait())
       if not success then
-        closer.errored = err
-        closer.check()
         return nil, err
       end
       err = coroutine.yield()

--- a/deps/coro-http.lua
+++ b/deps/coro-http.lua
@@ -1,6 +1,6 @@
 --[[lit-meta
   name = "creationix/coro-http"
-  version = "3.2.1"
+  version = "3.2.2"
   dependencies = {
     "creationix/coro-net@3.3.0",
     "luvit/http-codec@3.0.0"
@@ -38,6 +38,7 @@ local function createServer(host, port, onConnect)
       write("")
       if not head.keepAlive then break end
     end
+    write()
   end)
 end
 

--- a/deps/weblit-app.lua
+++ b/deps/weblit-app.lua
@@ -1,6 +1,6 @@
 --[[lit-meta
   name = "creationix/weblit-app"
-  version = "3.2.0"
+  version = "3.2.1"
   dependencies = {
     'creationix/coro-net@3.0.0',
     'luvit/http-codec@3.0.0',
@@ -27,7 +27,7 @@ local server = require('weblit-server').newServer(router.run)
 -- Forward router methods from app instance
 local serverMeta = {}
 function serverMeta:__index(name)
-  if type(router[name] == "function") then
+  if type(router[name]) == "function" then
     return function(...)
       router[name](...)
       return self


### PR DESCRIPTION
A simple server to reproduce this is:
```lua
require('coro-http').createServer("127.0.0.1", 8080, function(req)
    p(req)
    return {
        code = 200,
        reason = "OK",
        {"Content-Length", "6"},
        -- Also test with this uncommented, but it should work with both.
        -- {"Connection", "close"},
    }, "hello\n"
end)
p 'http://localhost:8080/'
```

In another terminal, watch the sockets:

```sh
while true; do clear && netstat -an | grep 8080 && sleep 1; done
```

Initially you should only the listening socket:
```
tcp        0      0 127.0.0.1:8080          0.0.0.0:*               LISTEN     
```

And in another, hit the server using curl:

```sh
curl -v http://localhost:8080/test
```

When you have `Connection: closed` commented out, curl should report the server supports http keepalive:

```
...
* Connection #0 to host localhost left intact
```

And when you uncomment it, it should change to:

```
...
* Closing connection 0
```

But in all cases, the only sockets should be the `LISTEN` for the server and then `TIME_WAIT` lines for the past properly closed requests. (These eventually timeout, you can ignore them.  They prevent the kernel from reusing the same socket pair too soon)

Before this fix, you would see the leak with lots of connections with `FIN_WAIT2` in the client side sockets and `CLOSE_WAIT` on the server side.  The `FIN_WAIT2` sockets will eventually timeout and go away, but the `CLOSE_WAIT` sockets leak and hang around till the server dies.

