### PR TITLE
coro-split: fixing coroutine resume before yielding

### DIFF
--- a/deps/coro-split.lua
+++ b/deps/coro-split.lua
@@ -27,9 +27,10 @@ return function (...)
   local thread = coroutine.running()
   local left = #tasks
   local results = {}
+  local yielded = false
   local function check()
     left = left - 1
-    if left == 0 then
+    if left == 0 and yielded then
       assertResume(thread, unpack(results))
     end
   end
@@ -39,5 +40,9 @@ return function (...)
       check()
     end)()
   end
+  if left <= 0 then
+    return unpack(results)
+  end
+  yielded = true
   return coroutine.yield()
 end

--- a/deps/coro-split.lua
+++ b/deps/coro-split.lua
@@ -1,6 +1,6 @@
 --[[lit-meta
   name = "creationix/coro-split"
-  version = "2.0.1"
+  version = "2.0.2"
   homepage = "https://github.com/luvit/lit/blob/master/deps/coro-split.lua"
   description = "An coro style helper for running tasks concurrently."
   tags = {"coro", "split"}


### PR DESCRIPTION
**Issue:**

If you try the following code
```lua
require'coro-split'(
  function()
    print(1)
    print(2)
  end,
  function()
    print(3)
    print(4)
  end,
  function()
    print(5)
    print(6)
  end
)
```
it would error with the said error message after it executed everything successfully
```
cannot resume running coroutine
```

**Explanation:**

That's due to all tasks being spawned and completed before `coroutine.yield` have been reached, therefor the `coroutine.resume` in `check` would fail.

**Solution:**
Basically make sure you only resume if yield have been executed (or tagged as so), otherwise return without yielding.
 