### PR TITLE
WIP: Allow using lit-package.json instead of package.lua / init.lua (needs feedback :D)

### DIFF
--- a/commands/init.lua
+++ b/commands/init.lua
@@ -127,7 +127,7 @@ elseif output == "lit-package.json" then
 		"email": %q
 	},
     "homepage": %q,
-    "dependencies": {},
+    "dependencies": [],
     "files": [
       "**.lua",
       "!test*"

--- a/commands/init.lua
+++ b/commands/init.lua
@@ -11,14 +11,14 @@ return function ()
   local config = core.config
 
   local function getOutput()
-    local output = prompt("Output to package.lua (1), or a init.lua (2)?")
+    local output = prompt("Output to package.lua (1), init.lua (2), or lit-package.json (3)?")
     -- response was blank, run again
     if not output then
       return getOutput()
     end
     -- fail on any other options
-    if not output:match('[1-2]') then
-      log("Error", "You must select a valid option. [1 or 2]")
+    if not output:match('[1-3]') then
+      log("Error", "You must select a valid option. [1, 2, or 3]")
       return getOutput()
     else
       if output == "1" then
@@ -27,6 +27,9 @@ return function ()
       elseif output == "2" then
         output = "init.lua"
         log("Creating", "init.lua")
+      elseif output == "3" then
+        output = "lit-package.json"
+        log("Creating", "lit-package.json")
       end
     end
     return output
@@ -111,6 +114,34 @@ return function ()
   }
   ]]
     data = sprintf(package, projectName, projectVersion, projectDescription, projectTags, projectLicense, authorName, authorEmail, projectHomepage)
+elseif output == "lit-package.json" then
+    local package = [[
+  {
+    "name": %q,
+    "version": %q,
+    "description": %q,
+    "tags": %s,
+    "license": %q,
+    "author": {
+		"name": %q,
+		"email": %q
+	},
+    "homepage": %q,
+    "dependencies": {},
+    "files": [
+      "**.lua",
+      "!test*"
+    ]
+  }
+  ]]
+
+    local function toJsonArray(luaTableString)
+        luaTableString = luaTableString:gsub("{", "[")
+        luaTableString = luaTableString:gsub("}", "]")
+        return luaTableString
+    end
+
+    data = sprintf(package, projectName, projectVersion, projectDescription, toJsonArray(projectTags), projectLicense, authorName, authorEmail, projectHomepage)
   end
 
   -- give us a preview

--- a/commands/make.lua
+++ b/commands/make.lua
@@ -2,14 +2,37 @@ return function ()
   local core = require('core')()
   local uv = require('uv')
   local pathJoin = require('luvi').path.join
+  local fs = require("coro-fs")
+  local json = require "json"
+  local dump = require "serpent".dump
 
   local cwd = uv.cwd()
   local source = args[2] and pathJoin(cwd, args[2])
   local target = args[3] and pathJoin(cwd, args[3])
   local luvi_source = args[4] and pathJoin(cwd, args[4])
+
+  local needsCleanup
+  local expectedLitPackageJsonPath = cwd .. "/lit-package.json"
+  local expectedLitPackageLuaPath = cwd .. "/package.lua"
+  if fs.stat(expectedLitPackageJsonPath) and not fs.stat(expectedLitPackageLuaPath) then
+    -- This isn't great, but we don't want to delete regular package definitions if they exist
+    print("Found Lit Package Definition at " .. expectedLitPackageJsonPath)
+    local fileContents = fs.readFile(expectedLitPackageJsonPath)
+    local table = json.decode(fileContents)
+    fs.writeFile(expectedLitPackageLuaPath, dump(table))
+    print("Created Lua package definition at " .. expectedLitPackageLuaPath)
+    needsCleanup = true
+  end
+
   if not source or uv.fs_access(source, "r") then
     core.make(source or cwd, target, luvi_source)
   else
     core.makeUrl(args[2], target, luvi_source)
   end
+
+  if needsCleanup then
+    print("Cleaning up temporary lua package definition at " .. expectedLitPackageLuaPath)
+    fs.unlink(expectedLitPackageLuaPath)
+  end
+
 end

--- a/libs/serpent.lua
+++ b/libs/serpent.lua
@@ -1,0 +1,275 @@
+local n, v = "serpent", "0.302" -- (C) 2012-18 Paul Kulchenko; MIT License
+local c, d = "Paul Kulchenko", "Lua serializer and pretty printer"
+local snum = {
+	[tostring(1 / 0)] = "1/0 --[[math.huge]]",
+	[tostring(-1 / 0)] = "-1/0 --[[-math.huge]]",
+	[tostring(0 / 0)] = "0/0"
+}
+local badtype = {thread = true, userdata = true, cdata = true}
+local getmetatable = debug and debug.getmetatable or getmetatable
+local pairs = function(t)
+	return next, t
+end -- avoid using __pairs in Lua 5.2+
+local keyword, globals, G = {}, {}, (_G or _ENV)
+for _, k in ipairs(
+	{
+		"and",
+		"break",
+		"do",
+		"else",
+		"elseif",
+		"end",
+		"false",
+		"for",
+		"function",
+		"goto",
+		"if",
+		"in",
+		"local",
+		"nil",
+		"not",
+		"or",
+		"repeat",
+		"return",
+		"then",
+		"true",
+		"until",
+		"while"
+	}
+) do
+	keyword[k] = true
+end
+for k, v in pairs(G) do
+	globals[v] = k
+end -- build func to name mapping
+for _, g in ipairs({"coroutine", "debug", "io", "math", "string", "table", "os"}) do
+	for k, v in pairs(type(G[g]) == "table" and G[g] or {}) do
+		globals[v] = g .. "." .. k
+	end
+end
+
+local function s(t, opts)
+	local name, indent, fatal, maxnum = opts.name, opts.indent, opts.fatal, opts.maxnum
+	local sparse, custom, huge = opts.sparse, opts.custom, not opts.nohuge
+	local space, maxl = (opts.compact and "" or " "), (opts.maxlevel or math.huge)
+	local maxlen, metatostring = tonumber(opts.maxlength), opts.metatostring
+	local iname, comm = "_" .. (name or ""), opts.comment and (tonumber(opts.comment) or math.huge)
+	local numformat = opts.numformat or "%.17g"
+	local seen, sref, syms, symn = {}, {"local " .. iname .. "={}"}, {}, 0
+	local function gensym(val)
+		return "_" ..
+			(tostring(tostring(val)):gsub("[^%w]", ""):gsub(
+				"(%d%w+)",
+				-- tostring(val) is needed because __tostring may return a non-string value
+				function(s)
+					if not syms[s] then
+						symn = symn + 1
+						syms[s] = symn
+					end
+					return tostring(syms[s])
+				end
+			))
+	end
+	local function safestr(s)
+		return type(s) == "number" and tostring(huge and snum[tostring(s)] or numformat:format(s)) or
+			type(s) ~= "string" and tostring(s) or -- escape NEWLINE/010 and EOF/026
+			("%q"):format(s):gsub("\010", "n"):gsub("\026", "\\026")
+	end
+	local function comment(s, l)
+		return comm and (l or 0) < comm and " --[[" .. select(2, pcall(tostring, s)) .. "]]" or ""
+	end
+	local function globerr(s, l)
+		return globals[s] and globals[s] .. comment(s, l) or not fatal and safestr(select(2, pcall(tostring, s))) or
+			error("Can't serialize " .. tostring(s))
+	end
+	local function safename(path, name) -- generates foo.bar, foo[3], or foo['b a r']
+		local n = name == nil and "" or name
+		local plain = type(n) == "string" and n:match("^[%l%u_][%w_]*$") and not keyword[n]
+		local safe = plain and n or "[" .. safestr(n) .. "]"
+		return (path or "") .. (plain and path and "." or "") .. safe, safe
+	end
+	local alphanumsort =
+		type(opts.sortkeys) == "function" and opts.sortkeys or
+		function(k, o, n) -- k=keys, o=originaltable, n=padding
+			local maxn, to = tonumber(n) or 12, {number = "a", string = "b"}
+			local function padnum(d)
+				return ("%0" .. tostring(maxn) .. "d"):format(tonumber(d))
+			end
+			table.sort(
+				k,
+				function(a, b)
+					-- sort numeric keys first: k[key] is not nil for numerical keys
+					return (k[a] ~= nil and 0 or to[type(a)] or "z") .. (tostring(a):gsub("%d+", padnum)) <
+						(k[b] ~= nil and 0 or to[type(b)] or "z") .. (tostring(b):gsub("%d+", padnum))
+				end
+			)
+		end
+	local function val2str(t, name, indent, insref, path, plainindex, level)
+		local ttype, level, mt = type(t), (level or 0), getmetatable(t)
+		local spath, sname = safename(path, name)
+		local tag =
+			plainindex and ((type(name) == "number") and "" or name .. space .. "=" .. space) or
+			(name ~= nil and sname .. space .. "=" .. space or "")
+		if seen[t] then -- already seen this element
+			sref[#sref + 1] = spath .. space .. "=" .. space .. seen[t]
+			return tag .. "nil" .. comment("ref", level)
+		end
+		-- protect from those cases where __tostring may fail
+		if type(mt) == "table" and metatostring ~= false then
+			local to, tr =
+				pcall(
+				function()
+					return mt.__tostring(t)
+				end
+			)
+			local so, sr =
+				pcall(
+				function()
+					return mt.__serialize(t)
+				end
+			)
+			if (to or so) then -- knows how to serialize itself
+				seen[t] = insref or spath
+				t = so and sr or tr
+				ttype = type(t)
+			end -- new value falls through to be serialized
+		end
+		if ttype == "table" then
+			if level >= maxl then
+				return tag .. "{}" .. comment("maxlvl", level)
+			end
+			seen[t] = insref or spath
+			if next(t) == nil then
+				return tag .. "{}" .. comment(t, level)
+			end -- table empty
+			if maxlen and maxlen < 0 then
+				return tag .. "{}" .. comment("maxlen", level)
+			end
+			local maxn, o, out = math.min(#t, maxnum or #t), {}, {}
+			for key = 1, maxn do
+				o[key] = key
+			end
+			if not maxnum or #o < maxnum then
+				local n = #o -- n = n + 1; o[n] is much faster than o[#o+1] on large tables
+				for key in pairs(t) do
+					if o[key] ~= key then
+						n = n + 1
+						o[n] = key
+					end
+				end
+			end
+			if maxnum and #o > maxnum then
+				o[maxnum + 1] = nil
+			end
+			if opts.sortkeys and #o > maxn then
+				alphanumsort(o, t, opts.sortkeys)
+			end
+			local sparse = sparse and #o > maxn -- disable sparsness if only numeric keys (shorter output)
+			for n, key in ipairs(o) do
+				local value, ktype, plainindex = t[key], type(key), n <= maxn and not sparse
+				if
+					opts.valignore and opts.valignore[value] or -- skip ignored values; do nothing
+						opts.keyallow and not opts.keyallow[key] or
+						opts.keyignore and opts.keyignore[key] or
+						opts.valtypeignore and opts.valtypeignore[type(value)] or -- skipping ignored value types
+						sparse and value == nil
+				 then -- skipping nils; do nothing
+				elseif ktype == "table" or ktype == "function" or badtype[ktype] then
+					if not seen[key] and not globals[key] then
+						sref[#sref + 1] = "placeholder"
+						local sname = safename(iname, gensym(key)) -- iname is table for local variables
+						sref[#sref] = val2str(key, sname, indent, sname, iname, true)
+					end
+					sref[#sref + 1] = "placeholder"
+					local path = seen[t] .. "[" .. tostring(seen[key] or globals[key] or gensym(key)) .. "]"
+					sref[#sref] = path .. space .. "=" .. space .. tostring(seen[value] or val2str(value, nil, indent, path))
+				else
+					out[#out + 1] = val2str(value, key, indent, nil, seen[t], plainindex, level + 1)
+					if maxlen then
+						maxlen = maxlen - #out[#out]
+						if maxlen < 0 then
+							break
+						end
+					end
+				end
+			end
+			local prefix = string.rep(indent or "", level)
+			local head = indent and "{\n" .. prefix .. indent or "{"
+			local body = table.concat(out, "," .. (indent and "\n" .. prefix .. indent or space))
+			local tail = indent and "\n" .. prefix .. "}" or "}"
+			return (custom and custom(tag, head, body, tail, level) or tag .. head .. body .. tail) .. comment(t, level)
+		elseif badtype[ttype] then
+			seen[t] = insref or spath
+			return tag .. globerr(t, level)
+		elseif ttype == "function" then
+			seen[t] = insref or spath
+			if opts.nocode then
+				return tag .. "function() --[[..skipped..]] end" .. comment(t, level)
+			end
+			local ok, res = pcall(string.dump, t)
+			local func = ok and "((loadstring or load)(" .. safestr(res) .. ",'@serialized'))" .. comment(t, level)
+			return tag .. (func or globerr(t, level))
+		else
+			return tag .. safestr(t)
+		end -- handle all other types
+	end
+	local sepr = indent and "\n" or ";" .. space
+	local body = val2str(t, name, indent) -- this call also populates sref
+	local tail = #sref > 1 and table.concat(sref, sepr) .. sepr or ""
+	local warn =
+		opts.comment and #sref > 1 and space .. "--[[incomplete output with shared/self-references skipped]]" or ""
+	return not name and body .. warn or "do local " .. body .. sepr .. tail .. "return " .. name .. sepr .. "end"
+end
+
+local function deserialize(data, opts)
+	local env =
+		(opts and opts.safe == false) and G or
+		setmetatable(
+			{},
+			{
+				__index = function(t, k)
+					return t
+				end,
+				__call = function(t, ...)
+					error("cannot call functions")
+				end
+			}
+		)
+	local f, res = (loadstring or load)("return " .. data, nil, nil, env)
+	if not f then
+		f, res = (loadstring or load)(data, nil, nil, env)
+	end
+	if not f then
+		return f, res
+	end
+	if setfenv then
+		setfenv(f, env)
+	end
+	return pcall(f)
+end
+
+local function merge(a, b)
+	if b then
+		for k, v in pairs(b) do
+			a[k] = v
+		end
+	end
+	return a
+end
+return {
+	_NAME = n,
+	_COPYRIGHT = c,
+	_DESCRIPTION = d,
+	_VERSION = v,
+	serialize = s,
+	load = deserialize,
+	dump = function(a, opts)
+		return s(a, merge({name = "_", compact = true, sparse = true}, opts))
+	end,
+	line = function(a, opts)
+		return s(a, merge({sortkeys = true, comment = true}, opts))
+	end,
+	block = function(a, opts)
+		return s(a, merge({indent = "  ", sortkeys = true, comment = true}, opts))
+	end
+}


### PR DESCRIPTION
Goals:

* Allow using JSON-based package definitions without altering any of the standard lit workflows (because it provides a clear separation between package metadata and Lua application code)
* Creating executables via ``lit make`` should still work (this was my primary use case), without any changes
* Don't alter any internals because the code is absolutely terrifying and everything will break... :cold_sweat: 

Changes:

* ``lit init`` supports a third format, ``lit-package.json`` (includes the exact same information, encoded as JSON)
* ``lit make`` creates a temporary ``package.lua`` file when ``lit-package.json`` exists, uses it for the build process, then deletes it
* The other commands aren't yet updated; I wasn't sure what needs changing, but I suppose every command must work with this format (feedback is required since I don't know the code well enough, or how people work with lit packages)

Potential Problems:

- [ ] It currently alters only the ``lit init`` and ``lit make`` commands (I'm not sure which of the other ones need to be updated)
- [ ] It requires using a table serialization library (introducing additional dependencies is... not great)
- [ ] I don't know how to test everything's working since there's barely anything in the ``tests`` folder...
- [ ] It currently only works if the ``lit-package.json`` exists and no ``package.lua`` format is used (priorities?)