### PR TITLE
Create GitHub Actions workflow to automatically publish releases on tag (including windows binary)

### DIFF
--- a/.github/get-pinned-luvi-version.lua
+++ b/.github/get-pinned-luvi-version.lua
@@ -1,0 +1,5 @@
+-- This script is intended to be run by the CI, from the root directory
+local packageMetadata = dofile("package.lua")
+local requiredLuviVersion = packageMetadata.luvi.version -- In case of errors, the CI will abort (working as intended)
+
+print(requiredLuviVersion)

--- a/.github/workflows/release-tagged-versions.yaml
+++ b/.github/workflows/release-tagged-versions.yaml
@@ -1,0 +1,61 @@
+name: Release Tagged Versions
+
+on:
+  push:
+    tags:
+      - '*' # Push events to every tag not containing / (that's all of them...)
+
+jobs:
+  build:
+    name: Build Lit for Windows (x64)
+    runs-on: windows-latest
+
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v2
+        with:
+          path: lit
+          submodules: true
+
+      # This is somewhat complicated, but we want to avoid redundancy
+      # Since the required Luvi version is stored in package.lua
+      # extracting it using any Lua interpreter seems more sane than storing it elsewhere
+      # or trying to parse it using shell commands to get at the relevant information
+      - name: Install Luvit runtime # The version doesn't really matter, since it isn't used in the build process directly
+        run: curl https://github.com/truemedian/luvit-bin/releases/download/2021-09-26/luvit-bin-Windows-x86_64.zip --fail --location --output luvit-bin.zip && dir && Expand-Archive luvit-bin.zip && dir
+
+      - name: Determine the pinned Luvi version
+        # It's much easier extracting it using Luvit as a helper, though we could parse the package metadata directly
+        run: cd lit && ../luvit-bin/luvit.exe .github/get-pinned-luvi-version.lua > REQUIRED_LUVI_VERSION && cat REQUIRED_LUVI_VERSION
+
+      - name: Fetch Luvi bundler
+        run: git clone --recursive https://github.com/luvit/luvi.git
+
+      - name: Check out the pinned Luvi version
+        # It's an abomination, but I haven't found a better way
+        run: dir && cd luvi && dir && iex "git checkout $(cat ../lit/REQUIRED_LUVI_VERSION)"
+
+      - name: Make Luvi executable
+        run: cd luvi && ./make.bat
+
+      - name: Create zip archive
+        uses: papeloto/action-zip@v1
+        with:
+          files: lit
+          dest: lit.zip
+
+      - name: Make Lit executable
+        shell: cmd
+        run: cd luvi && luvi.exe ../lit.zip --output ../lit.exe
+
+      # We don't want to deploy a faulty release, so this should fail if the executable is broken
+      - name: Verify the build
+        # This should only cover the CLI functionality, with the internal logic being tested separately (on commit, not release)
+        run: luvit-bin/luvit.exe lit/tests/run-smoke-tests.lua lit.exe
+
+      - name: Publish new release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: lit.exe
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/tests/run-smoke-tests.lua
+++ b/tests/run-smoke-tests.lua
@@ -1,0 +1,39 @@
+-- Dependencies
+local ffi = require("ffi")
+
+-- Upvalues
+local format = string.format
+
+-- Allow running tests without passing the executable path to automatically test the installed version
+local cliArguments = args -- Where does this even come from? Seems like more hidden luvit magic
+
+local isWindows = (ffi.os == "Windows")
+local DEFAULT_EXECUTABLE_NAME = isWindows and "lit.exe" or "lit"
+local LIT_EXECUTABLE_PATH = cliArguments[2] or DEFAULT_EXECUTABLE_NAME
+
+print(isWindows, DEFAULT_EXECUTABLE_NAME, LIT_EXECUTABLE_PATH)
+
+local function RunSmokeTests()
+	print("Running smoke tests (build verification)\n")
+
+	-- All the CLI commands should probably be tested here (TODO: Actually implement these tests)
+	-- Note: This is far too large a task to do all at once, so adding more tests here gradually is recommended
+	local testCases = {
+		[LIT_EXECUTABLE_PATH] = true -- Test if the path is set correctly
+		-- This is the most basic test I can think of, poorly-structured and mostly intended to demonstrate a possible approach
+		-- If the command has any side effects, like installing packages etc., they should be tested, too
+	}
+
+	for command, _ in pairs(testCases) do
+		print(format("Testing command: %s\n", command))
+
+		local success = os.execute(command)
+		assert(success == true, "Failed to execute " .. command)
+
+		print(format("All test passed for command: %s", command))
+	end
+
+	print("\nBuild Verification suceeded")
+end
+
+RunSmokeTests()


### PR DESCRIPTION
## What does it do?

* Set up a CI workflow to automatically publish a release on tag
* Build a ``lit.exe`` (Windows x64 binary) and append it to the release
* In order to build it, the pinned Luvi version is taken from ``package.lua`` (this part is ugly... suggestions welcome)
* After the executable is built, a basic smoke test suite is run to verify the build (currently placeholder/POC implementation. One step at a time :P)

## Why is it needed?

Technically it isn't needed, but making ``lit`` accessible without having to deal with PowerShell will improve the accessibility for new/inexperienced, or even just lazy users. This is not the best solution I can imagine to improve the new user experience, but it is a step in the right direction nonetheless.

This would also allow linking the release directly on the website, where currently a placeholder TODO text is located. I probably don't need to tell you again how bad of a first impression that is, so let's move one step closer to changing it :)

## Why no OS X/Unix/etc builds?

I don't think users of these systems are nearly as allergic to CLIs as the average Windows user, and setting things up with the existing ``makefile`` is probably easy enough for now. Creating a proper OS X installer seems like it could be valuable, but I have no such system available so it'll have to wait until a later point in time.

It's also probably better to create one installer for all components, which is something I've been looking into as well (work in progress) but otherwise unrelated to this PR.

## Why make Luvi from scratch instead of downloading a release?

Originally, I had intended to always use the latest version (and make the executable after ``git clone``). If the version is to be pinned, as it currently is, then one could just as easily download the executable and use it directly, but this wouldn't be as flexible so I can't re-use the workflow for modified versions or other related tasks.

Not sure on this one TBH, if you like I can easily change it.

## Demo

This is a full run of the current iteration of the workflow: https://github.com/LuvitPlayground/lit/runs/3752015499

The release is currently very barebones, but it looks like this: https://github.com/LuvitPlayground/lit/releases/tag/windows-build-demo-release

Note: In order to use this workflow, a GitHub Token must be added as a repository secret (to actually publish the release).
