### PR TITLE
secure-socket: more accurate error messages

### DIFF
--- a/deps/secure-socket/biowrap.lua
+++ b/deps/secure-socket/biowrap.lua
@@ -51,7 +51,13 @@ return function (ctx, isServer, socket, handshakeComplete, servername)
       local success, result = ssl:getpeerverification()
       socket:read_stop()
       if not success and result then
-        handshakeComplete("Error verifying peer: " .. result[1].error_string)
+        local errorString
+        for i=1, #result do
+          if not result[i].preverify_ok then
+            errorString = result[i].error_string
+          end
+        end
+        handshakeComplete("Error verifying peer: " .. errorString)
       end
       handshakeComplete(nil, ssocket)
     end

--- a/deps/secure-socket/biowrap.lua
+++ b/deps/secure-socket/biowrap.lua
@@ -51,13 +51,12 @@ return function (ctx, isServer, socket, handshakeComplete, servername)
       local success, result = ssl:getpeerverification()
       socket:read_stop()
       if not success and result then
-        local errorString
         for i=1, #result do
           if not result[i].preverify_ok then
-            errorString = result[i].error_string
+            handshakeComplete("Error verifying peer: " .. result[i].error_string)
+            break
           end
         end
-        handshakeComplete("Error verifying peer: " .. errorString)
       end
       handshakeComplete(nil, ssocket)
     end


### PR DESCRIPTION
This removes the assumption that the unverified cert is the first in the chain, if additional certs are supplied this reports an error message that looks like `Error verifying peer: ok`.

Before the changes: 
![image](https://user-images.githubusercontent.com/38175840/135467028-53369472-0db4-4269-b4d6-9f91b2ef485d.png)

After the changes:
![image](https://user-images.githubusercontent.com/38175840/135467179-2f809283-b2c0-46bc-8cee-e4f754e4efd0.png)

This might still be ambiguous to the user although, as in, the browser could still be able to access a said website -since the main cert is valid- but coro-net for example could not access it because one of the additional certs is invalid. Perhaps we can somehow report which cert is exactly unverified?