### PR TITLE
add secure socket to dependencies of coro-net

### DIFF
--- a/deps/coro-net.lua
+++ b/deps/coro-net.lua
@@ -4,6 +4,7 @@
   dependencies = {
     "creationix/coro-channel@3.0.0",
     "creationix/coro-wrapper@3.0.0",
+    "luvit/secure-socket"
   }
   optionalDependencies = {
     "luvit/secure-socket@1.0.0"


### PR DESCRIPTION
I added secure socket to the dependencies list of coro-net to prevent a error that im getting

`Uncaught Error: [string "bundle:deps/require.lua"]:279: No such module 'secure-socket' in 'bundle:/deps/coro-net.lua'
module 'secure-socket' not found:
        no field package.preload['secure-socket']
        no file './secure-socket.lua'
        no file '/usr/local/share/luajit-2.1.0-beta3/secure-socket.lua'
        no file '/usr/local/share/lua/5.1/secure-socket.lua'
        no file '/usr/local/share/lua/5.1/secure-socket/init.lua'
        no file './secure-socket.so'
        no file '/usr/local/lib/lua/5.1/secure-socket.so'
        no file '/usr/local/lib/lua/5.1/loadall.so'`

Also this is my first pull request so correct me if im wrong 😄 