### PR TITLE
handle chunked encoding extensions in chunk header

### DIFF
--- a/deps/http-codec.lua
+++ b/deps/http-codec.lua
@@ -246,16 +246,21 @@ local function decoder()
   end
 
   function decodeChunked(chunk, index)
-    local len, term
-    len, term = match(chunk, "^(%x+)(..)", index)
-    if not len then return end
-    if term ~= "\r\n" then
-      -- Wait for full chunk-size\r\n header
-      if #chunk < 18 then return end
-      -- But protect against evil clients by refusing chunk-sizes longer than 16 hex digits.
-      error("chunk-size field too large")
+    local header = match(chunk, "^[^\r\n]+\r\n", index)
+    if not header then
+      if #chunk - index > 8192 then
+        error("chunk-size header too large")
+      end
     end
-    index = index + #len + 2
+
+    -- we ignore chunk extensions
+    local len = match(header, "^(%x+)")
+    -- But protect against evil clients by refusing chunk-sizes longer than 16 hex digits.
+    if not len or #len > 16 then
+      error("invalid chunk-size")
+    end
+
+    index = index + #header
     local offset = index - 1
     local length = tonumber(len, 16)
     if #chunk < offset + length + 2 then return end


### PR DESCRIPTION
This will also need a version bump and subsequent bump in `creationix/http-codec`.

The original code here did not properly account for chunked encoding extensions, which may be present but should be ignored.

As stated in [RFC 7230 Section 4.1](https://datatracker.ietf.org/doc/html/rfc7230#section-4.1):
```
chunk          = chunk-size [ chunk-ext ] CRLF
                 chunk-data CRLF
chunk-ext      = *( ";" chunk-ext-name [ "=" chunk-ext-val ] )

chunk-ext-name = token
chunk-ext-val  = token / quoted-string
```

The code used to verify the bug in the original and verify that this fixes it is:
```lua
local codec = require 'http-codec'

local payload = ([[
HTTP/1.1 200 OK
Transfer-Encoding: chunked

4; some_really_long_extension=true
test
0
]]):gsub('\n', '\r\n')

local decoder = codec.decoder()

local _, index = decoder(payload, 1)
local _, _ = decoder(payload, index)
```

This caused an in issue in the original code because it was looking for hex characters followed directly by a CRLF, and the extension pushes the chunk beyond the accepted "16 acceptable hex digits".