### PR TITLE
amendment: #305: fix missing return in decodeChunked when chunk header is missing

### DIFF
--- a/deps/http-codec.lua
+++ b/deps/http-codec.lua
@@ -251,6 +251,8 @@ local function decoder()
       if #chunk - index > 8192 then
         error("chunk-size header too large")
       end
+
+      return
     end
 
     -- we ignore chunk extensions


### PR DESCRIPTION
This passed through my test case. decodeChunked should return early if it does not have enough data to process.