### PR TITLE
Implement installing packages over Git

### DIFF
--- a/libs/calculate-deps.lua
+++ b/libs/calculate-deps.lua
@@ -16,81 +16,173 @@ limitations under the License.
 
 --]]
 
-local normalize = require('semver').normalize
 local gte = require('semver').gte
 local log = require('log').log
+local exec = require('exec')
 local queryDb = require('pkg').queryDb
 local colorize = require('pretty-print').colorize
+local queryGit = require('pkg').queryGit
+local normalize = require('semver').normalize
 
-return function (db, deps, newDeps)
+local gitSchemes = {
+  "^https?://", -- over http/s protocol
+  "^ssh://", -- over ssh protocol
+  "^git://", -- over git protocol
+  "^ftps?://", -- over ftp/s protocol
+  "^[^:]+:", -- over ssh protocol
+}
 
-  local addDep, processDeps
+local processDeps
+local db, deps
 
-  function processDeps(dependencies)
-    if not dependencies then return end
-    for alias, dep in pairs(dependencies) do
-      local name, version = dep:match("^([^@]+)@?(.*)$")
-      if #version == 0 then
-        version = nil
-      end
-      if type(alias) == "number" then
-        alias = name:match("([^/]+)$")
-      end
-      if not name:find("/") then
-        error("Package names must include owner/name at a minimum")
-      end
-      if version then
-        local ok
-        ok, version = pcall(normalize, version)
-        if not ok then
-          error("Invalid dependency version: " .. dep)
-        end
-      end
-      addDep(alias, name, version)
+local function isGit(dep)
+  for i = 1, #gitSchemes do
+    if dep:match(gitSchemes[i]) then
+      return true
     end
   end
+  return false
+end
 
-  function addDep(alias, name, version)
-    local meta = deps[alias]
-    if meta then
-      if name ~= meta.name then
-        local message = string.format("%s %s ~= %s",
-          alias, meta.name, name)
-        log("alias conflict", message, "failure")
-        return
-      end
-      if version then
-        if not gte(meta.version, version) then
-          local message = string.format("%s %s ~= %s",
-            alias, meta.version, version)
-          log("version conflict", message, "failure")
-          return
-        end
-      end
+local function resolveDep(alias, dep)
+  -- match for author/name@version
+  local name, version = dep:match("^([^@]+)@?(.*)$")
+  -- resolve alias name, in case it's a number (an array index)
+  if type(alias) == "number" then
+    alias = name:match("([^/]+)$")
+  end
+
+  -- make sure owner is provided
+  if not name:find("/") then -- FIXME: this does match on `author/` or `/package`
+    error("Package names must include owner/name at a minimum")
+  end
+
+  -- resolve version
+  if #version ~= 0 then
+    local ok
+    ok, version = pcall(normalize, version)
+    if not ok then
+      error("Invalid dependency version: " .. dep)
+    end
+  else
+    version = nil
+  end
+
+  -- check for already installed packages
+  local meta = deps[alias]
+  if meta then
+    -- is there an alias conflict?
+    if name ~= meta.name then
+      local message = string.format("%s %s ~= %s",
+        alias, meta.name, name)
+      log("alias conflict", message, "failure")
+    -- is there a version conflict?
+    elseif version and not gte(meta.version, version) then
+      local message = string.format("%s %s ~= %s",
+        alias, meta.version, version)
+      log("version conflict", message, "failure")
+    -- re-process package dependencies if everything is ok
     else
-      local author, pname = name:match("^([^/]+)/(.*)$")
-      local match, hash = db.match(author, pname, version)
-
-      if not match then
-        error("No such "
-          .. (version and "version" or "package") .. ": "
-          .. name
-          .. (version and '@' .. version or ''))
-      end
-      local kind
-      meta, kind, hash = assert(queryDb(db, hash))
-      meta.db = db
-      meta.hash = hash
-      meta.kind = kind
-      deps[alias] = meta
+      processDeps(meta.dependencies)
     end
-
-    processDeps(meta.dependencies)
-
+    return
   end
 
+  -- extract author and package names from "author/package"
+  -- and match against the local db for the resources
+  -- if not available locally, and an upstream is set, match the upstream db
+  local author, pname = name:match("^([^/]+)/(.*)$")
+  local match, hash = db.match(author, pname, version)
+
+  -- no such package has been found locally nor upstream
+  if not match then
+    error("No such "
+      .. (version and "version" or "package") .. ": "
+      .. name
+      .. (version and '@' .. version or ''))
+  end
+
+  -- query package metadata, and mark it for installation
+  local kind
+  meta, kind, hash = assert(queryDb(db, hash))
+  meta.db = db
+  meta.hash = hash
+  meta.kind = kind
+  deps[alias] = meta
+
+  -- handle the dependencies of the module
+  processDeps(meta.dependencies)
+end
+
+-- TODO: implement git protocol over https, to be used in case `git` cli isn't available
+-- TODO: implement someway to specify a branch/tag when fetching
+-- TODO: implement handling git submodules
+local function resolveGitDep(url)
+  -- fetch the repo tree, don't include any tags
+  log("fetching", colorize("highlight", url))
+  local _, stderr, code = exec("git", "fetch", "--no-tags", "--depth=1", "--recurse-submodules", url)
+
+  -- was the fetch successful?
+  if code ~= 0 then
+    if stderr:match("^ENOENT") then
+      error("Cannot find git. Please make sure git is installed and available.")
+    else
+      error(stderr:gsub("\n$", ""))
+    end
+  end
+
+  -- load the fetched module tree
+  local raw = db.storage.read("FETCH_HEAD")
+  local hash = raw:match("^(.-)\t\t.-\n$")
+  assert(hash and #hash ~= 0, "Attempt to retrive FETCH_HEAD")
+  hash = db.loadAs("commit", hash).tree
+
+  -- query module's metadata, and match author/name
+  local meta, kind
+  meta, kind, hash = assert(queryGit(db, hash))
+  local author, name = meta.name:match("^([^/]+)/(.*)$")
+
+  -- check for installed packages and their version
+  local oldMeta = deps[name]
+  if oldMeta and not gte(oldMeta.version, meta.version) then
+    local message = string.format("%s %s ~= %s",
+      name, oldMeta.version, meta.version)
+    log("version conflict", message, "failure")
+    return
+  end
+
+  -- create a ref/tags/author/name/version pointing to module's tree
+  db.write(author, name, meta.version, hash)
+
+  -- mark the dep for installation
+  meta.db = db
+  meta.hash = hash
+  meta.kind = kind
+  deps[name] = meta
+
+  -- handle the dependencies of the module
+  processDeps(meta.dependencies)
+end
+
+function processDeps(dependencies)
+  if not dependencies then return end
+  -- iterate through dependencies and resolve each entry
+  for alias, dep in pairs(dependencies) do
+    if isGit(dep) then
+      resolveGitDep(dep)
+    else
+      resolveDep(alias, dep)
+    end
+  end
+end
+
+return function (gitDb, depsMap, newDeps)
+  -- assign gitDb and depsMap to upvalue to be visible everywhere
+  -- then start processing newDeps
+  db, deps = gitDb, depsMap
   processDeps(newDeps)
 
+  -- collect all deps names and log them
   local names = {}
   for k in pairs(deps) do
     names[#names + 1] = k
@@ -102,7 +194,6 @@ return function (db, deps, newDeps)
     log("including dependency", string.format("%s (%s)",
       colorize("highlight", name), meta.path or meta.version))
   end
-
 
   return deps
 end

--- a/libs/calculate-deps.lua
+++ b/libs/calculate-deps.lua
@@ -24,7 +24,10 @@ local colorize = require('pretty-print').colorize
 local queryGit = require('pkg').queryGit
 local normalize = require('semver').normalize
 
-local gitSchemes = {
+local processDeps
+local db, deps
+
+local GIT_SCHEMES = {
   "^https?://", -- over http/s protocol
   "^ssh://", -- over ssh protocol
   "^git://", -- over git protocol
@@ -32,12 +35,9 @@ local gitSchemes = {
   "^[^:]+:", -- over ssh protocol
 }
 
-local processDeps
-local db, deps
-
 local function isGit(dep)
-  for i = 1, #gitSchemes do
-    if dep:match(gitSchemes[i]) then
+  for i = 1, #GIT_SCHEMES do
+    if dep:match(GIT_SCHEMES[i]) then
       return true
     end
   end
@@ -127,14 +127,14 @@ local function resolveGitDep(url)
     if stderr:match("^ENOENT") then
       error("Cannot find git. Please make sure git is installed and available.")
     else
-      error(stderr:gsub("\n$", ""))
+      error((stderr:gsub("\n$", "")))
     end
   end
 
   -- load the fetched module tree
   local raw = db.storage.read("FETCH_HEAD")
   local hash = raw:match("^(.-)\t\t.-\n$")
-  assert(hash and #hash ~= 0, "Attempt to retrive FETCH_HEAD")
+  assert(hash and #hash ~= 0, "Unable to retrieve FETCH_HEAD\n" .. raw)
   hash = db.loadAs("commit", hash).tree
 
   -- query module's metadata, and match author/name

--- a/libs/calculate-deps.lua
+++ b/libs/calculate-deps.lua
@@ -116,11 +116,11 @@ end
 
 -- TODO: implement git protocol over https, to be used in case `git` cli isn't available
 -- TODO: implement someway to specify a branch/tag when fetching
--- TODO: implement handling git submodules
+-- TODO: implement handling git submodules, or shall we not?
 local function resolveGitDep(url)
   -- fetch the repo tree, don't include any tags
   log("fetching", colorize("highlight", url))
-  local _, stderr, code = exec("git", "fetch", "--no-tags", "--depth=1", "--recurse-submodules", url)
+  local _, stderr, code = exec("git", "fetch", "--no-tags", "--depth=1", url)
 
   -- was the fetch successful?
   if code ~= 0 then

--- a/libs/pkg.lua
+++ b/libs/pkg.lua
@@ -22,9 +22,10 @@ Package Metadata Commands
 
 These commands work with packages metadata.
 
-pkg.query(fs, path) -> meta, path           - Query an on-disk path for package info.
-pkg.queryDb(db, path) -> meta, kind         - Query an in-db hash for package info.
-pky.normalize(meta) -> author, tag, version - Extract and normalize pkg info
+pkg.query(fs, path) -> meta, path            - Query an on-disk path for package info.
+pkg.queryDb(db, path) -> meta, kind, hash    - Query an in-db hash for package info.
+plg.queryGit(db, path) -> meta, kind, hash   - Query an in-db hash fetched with `git fetch` for package info.
+pky.normalize(meta) -> author, tag, version  - Extract and normalize pkg info
 ]]
 
 local isFile = require('git').modes.isFile
@@ -167,6 +168,46 @@ local function queryDb(db, hash)
   return meta, kind, hash
 end
 
+local function queryGit(db, hash)
+  local method = db.offlineLoadAny or db.load -- is rdb loaded?
+  local kind, value = method(hash)
+  if not kind then
+    error("Attempt to load the fetched tree")
+  elseif kind ~= "tree" then
+    error("Illegal kind: " .. kind)
+  end
+
+  local tree = listToMap(value)
+  local path = "tree:" .. hash
+  local entry = tree["package.lua"]
+  if entry then
+    path = path .. "/package.lua"
+  elseif tree["init.lua"] then
+    entry = tree["init.lua"]
+    path = path .. "/init.lua"
+  else
+    -- check if the tree only contains a single lua file, and treat it as a package.
+    -- since in most git hosting services you won't have blob-pointing tag,
+    -- this has to make some assumption (or otherwise not support it)
+    -- in this case, it makes the assumption that a single-file package's repo
+    -- only has a single lua file
+    for name, meta in pairs(tree) do
+      if name:sub(-4) == ".lua" and isFile(meta.mode) then
+        if entry then -- it contains more than a single lua file
+          return nil, "ENOENT: No package.lua or init.lua in tree:" .. hash
+        end
+        entry = tree[name]
+        path = "blob:" .. entry.hash
+        kind = "blob"
+        hash = entry.hash
+      end
+    end
+  end
+
+  local meta = evalModule(db.loadAs("blob", entry.hash), path)
+  return meta, kind, hash
+end
+
 local function normalize(meta)
   local author, tag = meta.name:match("^([^/]+)/(.*)$")
   return author, tag, semver.normalize(meta.version)
@@ -176,5 +217,6 @@ end
 return {
   query = query,
   queryDb = queryDb,
+  queryGit = queryGit,
   normalize = normalize,
 }

--- a/libs/rdb.lua
+++ b/libs/rdb.lua
@@ -24,7 +24,8 @@ local httpCodec = require('http-codec')
 local websocketCodec = require('websocket-codec')
 local makeRemote = require('codec').makeRemote
 local deframe = require('git').deframe
-local decodeTag = require('git').decoders.tag
+local decoders = require('git').decoders
+local decodeTag = decoders.tag
 local verifySignature = require('verify-signature')
 
 local function connectRemote(url, timeout)
@@ -139,6 +140,12 @@ return function(db, url, timeout)
     if raw then return raw end
     db.fetch({hash})
     return assert(db.offlineLoad(hash))
+  end
+
+  function db.offlineLoadAny(hash)
+    local raw = assert(db.offlineLoad(hash), "no such hash")
+    local kind, value = deframe(raw)
+    return kind, decoders[kind](value)
   end
 
   function db.fetch(list)


### PR DESCRIPTION
# The Pull Request

This is an initial PR of many planned PRs aiming at polishing the Lit experience. In this PR I wrote the basics of getting a `lit install https://github.com/author/repo` command working, as well as refactoring some of the code, and documenting it. I will go through every little change that I have made, and the expected behavior of such changes, as well as potential bugs that I spotted. But first I will explain how to use this implementation.

----------------------

# How to use it

I wanted to keep this as simple as it gets, and tried to not confuse the end-user and keep it familiar to them.  Therefor my choice was to use Git's URL scheme similar to how `git clone URL` works (and similar to how `lit make` currently handle this).  Some examples of the command:

- `lit install git@github.com:SinisterRectus/discordia` (over ssh)
- `lit install https://github.com/creationix/weblit` (over https)
- `lit install https://github.com/Bilal2453/discordia-replies.git` (over https, single-file package)

All of the above commands are expected (and tested) to work as one would expect it to.  Fetch the repo tree, calculate the dependencies, install the package correctly and then install the package's dependencies; Even if such dependencies are Git repos too. For example, a possible package.lua:

```lua
return {
    name = "author/package",
    version = "0.0.1",
    -- etc
    dependencies = { "git://github.com/Bilal2453/discordia-replies", "https://gitlab.com/Bilal2453/lit-git-test.git" },
}
```

It is as well expected to work with any Git upstream, in the above example GitLab and GitHub are used.

----------------------

# How it works

While in the process of making this implementation small and simple, I decided to reuse most of the Lit logic regarding Git DB, this implementation will use the Git CLI to fetch the given repo into Lit's DB, then it queries the package in-db (just like Lit currently does), then marks the package for installation. The installation process itself is untouched, the behavior from this point is identical to current Lit.

Single-file packages though, those have been very problematic to implement since you basically cannot tell a service (GitHub for example) to create tag pointing to the desired blob (how Lit currently does it), making us unable to determine which blob in the tree is the package file. I've been in front of two choices, either I don't implement it, or I search the tree for a Lua file, then if and only if the tree only has a single Lua file, use that as the package. I thought that "something is better than nothing" and went with the last method, I will have to document this behavior well since it may be a bit unexpected for the end-user.

----------------------

# Not yet implemented

TL;DR:
  - Implement a way of specifying the targeted branch, or tag, or commit hash (Any or all of them will do)
  - Internally implement Git protocol over HTTPS (smart HTTPS) to be used if Git binary is not available.
  - Handle Git submodules (?).

  As you might have noticed, this make use of `git` binary, that decision was for three reasons, first is `lit make` already making use of that, second for simplicity and to match the friendly behavior of Git as much as I could, and third me being limited on time. I am planning to implement the Git protocol internally over HTTPS, this will be soon in a future PR.

  This implementation will fetch whatever latest default branch is.  A way of specifying a commit, or a branch, or even a tag is mandatory. I although have been very conflicted over this and over how I will be implementing it. Since we are supporting all Git accepted URL schemes I am afraid that something similar to `lit install URL@tag` is going to conflict with the repo URL, and since we also have the SCP-like syntax `git@host:` being also used.
I basically am not sure what syntax to use for specifying a version(a commit hash, tag, branch, etc), and afraid of introducing a syntax that could potentially conflict with what Git expects/accept.  I've thought about implementing an `install-git` command just to solve this problem (with something like `lit install-git repo version`, but I will leave deciding this up to you, or to future me.

   Lastly, Git submodules. As you can see from the commit history of this PR, I used to actually have `--recurse-submodules` thinking that was everything into handle submodules... apparently no, handling submodules requires a very specific implementation that I didn't even find at the Git docs, the only mention of it I found was [this answer](https://stackoverflow.com/questions/46004365/how-is-submodules-feature-implemented-internally-if-it-uses-tracking-branch) on StackOverflow explaining how it is implemented. It is not terribly hard but it also isn't a straightforward, being tide up to time, I decided to not implement it in this PR, although in future PRs I will be trying to... *and perhaps failing*.
 
 ----------------------
 
 # Potential bugs in Lit
 
 While trying to understand how Lit works, I've had multiple "are you sure?" moments. None of which I fixed or even tried to. Here are ones I remember:

1. [calculate-deps.lua](https://github.com/luvit/lit/blob/master/libs/calculate-deps.lua#L39). This indicates that `lit install author/` is allowed. And indeed when I tried it with `lit install SinisterRectus/` it tried to do... something, not quite sure what it is trying to do (probably install first-to-match package) but it quickly fails with a somewhat unexpected error. Will be opening an issue about it.
 
2. [calculate-deps.lua](https://github.com/luvit/lit/blob/master/libs/calculate-deps.lua#L88). As I understand, this will try to process the dependencies of the package... what happens if two packages lists each other as a dependency? I haven't confirmed this but from what I am reading... it would be stuck in a recursive loop. No checks to prevent this from happening are provided.
 
3. [core.lua](https://github.com/luvit/lit/blob/master/libs/core.lua#L508). The field name has a typo, and this field is never used anywhere. Correcting it should break nothing...?
 
4. [core.lua](https://github.com/luvit/lit/blob/master/libs/core.lua#L510-L520). I wanted to match Git's accepted scheme for fetch, and found this in core... although I could just take the pattern part and leave the handler one, the name of this field does not imply it is related to `lit make` nor I think it makes sense to expose it as such.
 
----------------------
 
# Change overview
  
  Here I will list most behavior changes, additions, or deletions I've made to the existence code.
  
  1. rdb.lua:
     - [Added](https://github.com/Bilal2453/lit/commit/77c8795e5a45fa3fb78d52f28ad4b205d1fc7ebc#diff-477b241d3b39baae90be2b546e5526461a4f97d7ef1568e147835b6a4c30b165R145-R150) `db.offlineLoadAny`. Because rdb patches `db.load`, it makes it impossible to use `db.loadAny` locally without triggering the upstream matching. This solves it by re-implementing loadAny but with the `offloadLoad` reference.
  2. pkg.lua:
     - [Added](https://github.com/Bilal2453/lit/commit/77c8795e5a45fa3fb78d52f28ad4b205d1fc7ebc#diff-bf3894ac288c9fc64e300a476777d1b985f393220bfdbe4a52f96831d099cd7cR171-R210) `pkg.queryGit`. It is pretty similar to `queryDb` except in that it is offline only, and handles single-file packages differently (as mentioned previously).
     - [Edited the doc comment](https://github.com/Bilal2453/lit/commit/77c8795e5a45fa3fb78d52f28ad4b205d1fc7ebc#diff-bf3894ac288c9fc64e300a476777d1b985f393220bfdbe4a52f96831d099cd7cR25-R28) to include `pkg.queryGit`, and to add `hash` as a return of `queryDb`.
  3. calculate-deps.lua (PR's main focus):
     - [Refactoring the code](https://github.com/Bilal2453/lit/commit/77c8795e5a45fa3fb78d52f28ad4b205d1fc7ebc#diff-7bd1d177373059349e1ec7f30b4819bdb546faa4e4c3ceb55785437aa04c25b1R179-R199) to stop using nesting functions inside other functions.
     - `addDep` & `processDeps` [logic is merged together into](https://github.com/Bilal2453/lit/commit/77c8795e5a45fa3fb78d52f28ad4b205d1fc7ebc#diff-7bd1d177373059349e1ec7f30b4819bdb546faa4e4c3ceb55785437aa04c25b1R47) `resolveDeps`.
     - Everything is now documented, with hopefully clear comments.
     - Old Lit behavior is untouched, except when package name starts with a Git scheme.
     - [Implemented](https://github.com/Bilal2453/lit/commit/77c8795e5a45fa3fb78d52f28ad4b205d1fc7ebc#diff-7bd1d177373059349e1ec7f30b4819bdb546faa4e4c3ceb55785437aa04c25b1R120) `resolveGitDeps` that handles git calculations (and fetching).
 
Those should be all of the changes introduced in this PR, hope I missed nothing. There should be 0 change over how Lit currently work. If you observe any, it is a bug.

----------------------

# Tests

To test this implementation I've made a really small repo at https://github.com/Bilal2453/lit-git-test/ which should be enough to show any odd behavior, it tests old dependencies resolution behavior, single-file package over Git, using multiple Git upstreams (GitHub and GitLab in this test), and rule excluding. Overall, it makes use of 3 upstreams, GitHub, GitLab and Lit.

----------------------

Finally, feel free to give me your feedback, review the code and test it, and contribute to the implementation. I hope this is up to the task of making Lit even better.
