### PR TITLE
HTTPS support

### DIFF
--- a/deps/coro-http.lua
+++ b/deps/coro-http.lua
@@ -15,10 +15,11 @@
 local httpCodec = require('http-codec')
 local net = require('coro-net')
 
-local function createServer(host, port, onConnect)
+local function createServer(host, port, tls, onConnect)
   return net.createServer({
     host = host,
     port = port,
+    tls = tls,
     encoder = httpCodec.encoder,
     decoder = httpCodec.decoder,
   }, function (read, write, socket)


### PR DESCRIPTION
I assume that this should bring HTTPS support into `createServer`. Of course, **this seems like a breaking change** (you will have to add `tls` argument to this function, to either ignore it or not), but that's only a concept. Maybe going one step further with just `options`?

After quick testing, coro-net works with this change (I have no certificate yet to test with, but from the error I assume that it will work with the certificate, setting `tls` to `false` or `_,` will avoid this error, at least it worked for me):
`/root/Luvit/deps/coro-net.lua:80: TLS servers require a certificate`