### PR TITLE
get-lit: update luvi to 2.14.0

### DIFF
--- a/get-lit.ps1
+++ b/get-lit.ps1
@@ -1,5 +1,5 @@
 
-$LUVI_VERSION = "2.12.0"
+$LUVI_VERSION = "2.14.0"
 $LIT_VERSION = "3.8.5"
 # Environment variables take precedence
 if (test-path env:LUVI_VERSION) { $LUVI_VERSION = $env:LUVI_VERSION }

--- a/get-lit.sh
+++ b/get-lit.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 set -eu
-LUVI_VERSION=${LUVI_VERSION:-2.12.0}
+LUVI_VERSION=${LUVI_VERSION:-2.14.0}
 LIT_VERSION=${LIT_VERSION:-3.8.5}
 
 LUVI_ARCH=`uname -s`_`uname -m`


### PR DESCRIPTION
This also workaround a mis-labled Luvi tag, v2.12.0 is in fact Luvi version `2.11.0-21` which causes an error with Lit's `core.getLuvi` not finding a tag for `2.12.0-21`. 