### PR TITLE
Create update-lit.sh

### DIFF
--- a/update-lit.sh
+++ b/update-lit.sh
@@ -1,11 +1,15 @@
 #!/bin/bash
 
 cecho() {
-	# foreground \033[48;2;RRR;GGG;BBBm
-	# background \033[38;2;RRR;GGG;BBBm
-	# clear      \033[0m
+        # foreground \033[48;2;RRR;GGG;BBBm
+        # background \033[38;2;RRR;GGG;BBBm
+        # clear      \033[0m
 
-	echo "\033[38;2;50;210;255m$1\033[0m";
+        if [ -z ${BASH_VERSION} ]; then # bash interpreter
+                echo "\033[38;2;50;210;255m$1\033[0m";
+        else # sh interpreter
+                echo -e "\033[38;2;50;210;255m$1\033[0m";
+        fi
 }
 
 while test $# -gt 0; do

--- a/update-lit.sh
+++ b/update-lit.sh
@@ -5,17 +5,17 @@ cecho() {
 	# background \033[38;2;RRR;GGG;BBBm
 	# clear      \033[0m
 
-	echo -e "\033[38;2;50;210;255m$1\033[0m";
+	echo "\033[38;2;50;210;255m$1\033[0m";
 }
 
 while test $# -gt 0; do
 	case "$1" in
 		-l|-last|--lastest )
-			cecho 'Checking the lit version...'
+			cecho 'Checking the lit version...';
 			LIT_VERSION=$(curl https://api.github.com/repos/luvit/lit/tags | grep -o -P '(?<=\"name\": \").*(?=\",)' | head -1);
 			cecho "Lastest lit release: $LIT_VERSION";
 
-			cecho 'Checking the luvi version...'
+			cecho 'Checking the luvi version...';
 			LUVI_VERSION=$(curl https://api.github.com/repos/luvit/luvi/releases/latest | grep -o -P '(?<=\"tag_name\": \"v).*(?=\",)');
 			cecho "Lastest luvi release: $LUVI_VERSION";
 
@@ -23,7 +23,7 @@ while test $# -gt 0; do
 		;;
 		-lit-ver|--lit-version )
 			if [ "$2" = 'latest' ]; then
-				cecho 'Checking the lit version...'
+				cecho 'Checking the lit version...';
 				LIT_VERSION=$(curl https://api.github.com/repos/luvit/lit/tags | grep -o -P '(?<=\"name\": \").*(?=\",)' | head -1);
 				cecho "Lastest lit release: $LIT_VERSION";
 			else
@@ -34,7 +34,7 @@ while test $# -gt 0; do
 		;;
 		-luvi-ver|--luvi-version )
 			if [ "$2" = 'latest' ]; then
-				cecho 'Checking the luvi version...'
+				cecho 'Checking the luvi version...';
 				LUVI_VERSION=$(curl https://api.github.com/repos/luvit/luvi/releases/latest | grep -o -P '(?<=\"tag_name\": \"v).*(?=\",)');
 				cecho "Lastest luvi release: $LUVI_VERSION";
 			else
@@ -44,16 +44,16 @@ while test $# -gt 0; do
 			shift 2;
 		;;
 		-h|--help)
-		cecho 'luvit-update - a update tool for lit/luvi/luvit';
-		echo ' ';
-		cecho 'luvit-update [options] [arguments]';
-		echo ' ';
-		cecho 'options:';
-		cecho '-h, --help                             Show help.';
-		cecho '-l, -last, --lastest                   Download lastest lit/luvi/luvit releases from github (by default updater works with versions get-lit.sh that updates manually).';
-		cecho '-lit-ver XXX, --lit-version YYY        Specify an lit version.';
-		cecho '-luvi-ver XXX, --luvi-version YYY      Specify an luvit version.';
-		exit 0;
+			cecho 'luvit-update - a update tool for lit/luvi/luvit';
+			echo ' ';
+			cecho 'luvit-update [options] [arguments]';
+			echo ' ';
+			cecho 'options:';
+			cecho '-h, --help                             Show help.';
+			cecho '-l, -last, --lastest                   Download lastest lit/luvi/luvit releases from github (by default updater works with versions get-lit.sh that updates manually).';
+			cecho '-lit-ver XXX, --lit-version YYY        Specify an lit version.';
+			cecho '-luvi-ver XXX, --luvi-version YYY      Specify an luvit version.';
+			exit 0;
 		;;
 		*)
 			break;
@@ -62,16 +62,16 @@ while test $# -gt 0; do
 done;
 
 if [ ! $LIT_VERSION ] || [ ! $LUVI_VERSION ]; then
-	cecho 'Request versions from get-lit.sh';
+	cecho 'Request versions from get-lit.sh (may a bit outdated since it is supported manually)';
 	GET_LIT=$(curl 'https://raw.githubusercontent.com/luvit/lit/master/get-lit.sh');
 
-	if [ !$LIT_VERSION ]; then
+	if [ ! $LIT_VERSION ]; then
 		LIT_VERSION=$(cecho "$GET_LIT" | grep -o -P '(?<=\${LIT_VERSION:-).*(?=})');
-		cecho "Lit release: $LIT_VERSION (may a bit outdated)";
+		cecho "Actual lit release: $LIT_VERSION";
 	fi
-	if [ !$LUVI_VERSION ]; then
+	if [ ! $LUVI_VERSION ]; then
 		LUVI_VERSION=$(cecho "$GET_LIT" | grep -o -P '(?<=\${LUVI_VERSION:-).*(?=})');
-		cecho "Luvi release: $LUVI_VERSION (may a bit outdated)";
+		cecho "Actual luvi release: $LUVI_VERSION";
 	fi
 fi
 
@@ -82,41 +82,55 @@ update() {
 
 	rm lit 2> /dev/null & rm luvi 2> /dev/null & rm luvit 2> /dev/null;
 
-	# Download Files
-	cecho "Downloading $LUVI_URL to luvi"
-	curl -L -f -o luvi $LUVI_URL
-	chmod +x luvi
-	cecho "Downloading $LIT_URL to lit.zip"
-	curl -L -f -o lit.zip $LIT_URL
-	# Create lit using lit
-	./luvi lit.zip -- make lit.zip lit luvi
-	# Cleanup
-	rm -f lit.zip
-	# Create luvit using lit
+	cecho "Downloading $LUVI_URL to luvi";
+	curl -L -f -o luvi $LUVI_URL;
+
+	cecho "Downloading $LIT_URL to lit.zip";
+	curl -L -f -o lit.zip $LIT_URL;
+
+	chmod +x luvi;
+	./luvi lit.zip -- make lit.zip lit luvi;
 	./lit make lit://luvit/luvit luvit luvi
+
+	rm -f lit.zip
 
 	exit 0;
 }
 
-if ! command -v lit > /dev/null
+LIT_EXECUTABLE=$(realpath './lit');
+if [ ! -x "$LIT_EXECUTABLE" ]; then
+    LIT_EXECUTABLE='lit';
+fi
+
+if ! command -v "$LIT_EXECUTABLE" > /dev/null
 then
 	cecho '  Lit is not installed';
 	update;
 fi
 
-if ! command -v luvi > /dev/null
+LUVI_EXECUTABLE=$(realpath './luvi');
+if [ ! -x "$LUVI_EXECUTABLE" ]; then
+    LUVI_EXECUTABLE='luvi';
+fi
+
+if ! command -v "$LUVI_EXECUTABLE" > /dev/null
 then
 	cecho '  Luvi is not installed';
 	update;
 fi
 
-if ! command -v luvit > /dev/null
+LUVIT_EXECUTABLE=$(realpath './luvit');
+if [ ! -x "$LUVIT_EXECUTABLE" ]; then
+    LUVIT_EXECUTABLE='luvit';
+fi
+
+if ! command -v "$LUVIT_EXECUTABLE" > /dev/null
 then
 	cecho '  Luvit is not installed';
 	update;
 fi
 
-LIT_VERSION_CUR=$(lit -v | grep -m1 -Po 'lit version:\s\K.*');
+LIT_VERSION_CUR=$($LIT_EXECUTABLE -v | grep -m1 -Po 'lit version:\s\K.*');
 cecho "Installed version of lit: $LIT_VERSION_CUR";
 
 if [ "$LIT_VERSION" != "$LIT_VERSION_CUR" ]; then
@@ -125,7 +139,7 @@ if [ "$LIT_VERSION" != "$LIT_VERSION_CUR" ]; then
 	update;
 fi
 
-LUVI_VERSION_CUR=$(luvi -v | grep -m1 -Po 'luvi v\K.*');
+LUVI_VERSION_CUR=$($LUVI_EXECUTABLE -v | grep -m1 -Po 'luvi v\K.*');
 cecho "Installed version of luvi: $LUVI_VERSION_CUR";
 
 if [ "$LUVI_VERSION" != "$LUVI_VERSION_CUR" ]; then

--- a/update-lit.sh
+++ b/update-lit.sh
@@ -10,14 +10,14 @@ cecho() {
 
 while test $# -gt 0; do
 	case "$1" in
-		-l|-last|--lastest )
+		-l|-last|--latest )
 			cecho 'Checking the lit version...';
 			LIT_VERSION=$(curl https://api.github.com/repos/luvit/lit/tags | grep -o -P '(?<=\"name\": \").*(?=\",)' | head -1);
-			cecho "Lastest lit release: $LIT_VERSION";
+			cecho "Latest lit release: $LIT_VERSION";
 
 			cecho 'Checking the luvi version...';
 			LUVI_VERSION=$(curl https://api.github.com/repos/luvit/luvi/releases/latest | grep -o -P '(?<=\"tag_name\": \"v).*(?=\",)');
-			cecho "Lastest luvi release: $LUVI_VERSION";
+			cecho "Latest luvi release: $LUVI_VERSION";
 
 			break;
 		;;
@@ -25,7 +25,7 @@ while test $# -gt 0; do
 			if [ "$2" = 'latest' ]; then
 				cecho 'Checking the lit version...';
 				LIT_VERSION=$(curl https://api.github.com/repos/luvit/lit/tags | grep -o -P '(?<=\"name\": \").*(?=\",)' | head -1);
-				cecho "Lastest lit release: $LIT_VERSION";
+				cecho "Latest lit release: $LIT_VERSION";
 			else
 				LIT_VERSION=$2;
 			fi
@@ -36,7 +36,7 @@ while test $# -gt 0; do
 			if [ "$2" = 'latest' ]; then
 				cecho 'Checking the luvi version...';
 				LUVI_VERSION=$(curl https://api.github.com/repos/luvit/luvi/releases/latest | grep -o -P '(?<=\"tag_name\": \"v).*(?=\",)');
-				cecho "Lastest luvi release: $LUVI_VERSION";
+				cecho "Latest luvi release: $LUVI_VERSION";
 			else
 				LUVI_VERSION=$2;
 			fi
@@ -50,7 +50,7 @@ while test $# -gt 0; do
 			echo ' ';
 			cecho 'options:';
 			cecho '-h, --help                             Show help.';
-			cecho '-l, -last, --lastest                   Download lastest lit/luvi/luvit releases from github (by default updater works with versions get-lit.sh that updates manually).';
+			cecho '-l, -last, --latest                    Download latest lit/luvi/luvit releases from github (by default updater works with versions get-lit.sh that updates manually).';
 			cecho '-lit-ver XXX, --lit-version YYY        Specify an lit version.';
 			cecho '-luvi-ver XXX, --luvi-version YYY      Specify an luvit version.';
 			exit 0;

--- a/update-lit.sh
+++ b/update-lit.sh
@@ -1,0 +1,59 @@
+#!/bin/sh
+
+echo 'Checking for available updates...';
+
+GET_LIT=$(curl 'https://raw.githubusercontent.com/luvit/lit/master/get-lit.sh')
+
+shouldUpdate() {
+	use "$GET_LIT";
+
+	if ! command -v lit > /dev/null
+	then
+		echo 'Lit not installed';
+		return 0;
+	fi
+
+	if ! command -v luvi > /dev/null
+	then
+		echo 'Luvi not installed';
+		return 0;
+	fi
+
+	if ! command -v luvit > /dev/null
+	then
+		echo 'Luvit not installed';
+		return 0;
+	fi
+
+	CUR_LIT=$(lit -v | grep -m1 -Po 'lit version:\s\K.*');
+	ACTUAL_LIT=$(echo "$GET_LIT" | grep -o -P "(?<=\${LIT_VERSION:-).*(?=})");
+
+	if [ "$CUR_LIT" != "$ACTUAL_LIT" ]; then
+		echo 'Lit needs update';
+		return 0;
+	fi
+
+	CUR_LUVI=$(luvi -v | grep -m1 -Po 'luvi version:\s\K.*');
+	ACTUAL_LUVI=$(echo "$GET_LIT" | grep -o -P "(?<=\${LUVI_VERSION:-).*(?=})");
+
+	if [ "$CUR_LUVI" != "$ACTUAL_LUVI" ]; then
+		echo 'Luvi needs update';
+		return 0;
+	fi
+
+	CUR_LUVIT=$(luvit -v | grep -m1 -Po 'luvit version:\s\K.*');
+	ACTUAL_LUVIT=$(curl https://api.github.com/repos/luvit/luvit/releases/latest | grep -o -P "(?<=\"name\": \").*(?=\",)");
+
+	if [ "$CUR_LUVIT" != "$ACTUAL_LUVIT" ]; then
+		echo 'Luvit needs update';
+		return 0;
+	fi
+
+	return 1;
+}
+
+if shouldUpdate; then
+	echo 'Update...';
+	cd '/usr/bin/' || exit;
+	bash -c "$GET_LIT";
+fi

--- a/update-lit.sh
+++ b/update-lit.sh
@@ -1,83 +1,123 @@
-#!/bin/sh
+#!/bin/bash
 
-echo 'Checking for available updates...';
+cecho() {
+	# foreground \033[48;2;RRR;GGG;BBBm
+	# background \033[38;2;RRR;GGG;BBBm
+	# clear      \033[0m
 
-GET_LIT=$(curl 'https://raw.githubusercontent.com/luvit/lit/master/get-lit.sh')
-
-shouldUpdate() {
-	if ! command -v lit > /dev/null
-	then
-		echo 'Lit is not installed';
-		return 0;
-	fi
-
-	if ! command -v luvi > /dev/null
-	then
-		echo 'Luvi is not installed';
-		return 0;
-	fi
-
-	if ! command -v luvit > /dev/null
-	then
-		echo 'Luvit is not installed';
-		return 0;
-	fi
-
-	echo 'Checking the lit version...';
-
-	CUR_LIT=$(lit -v | grep -m1 -Po 'lit version:\s\K.*');
-	ACTUAL_LIT=$(echo "$GET_LIT" | grep -o -P '(?<=\${LIT_VERSION:-).*(?=})');
-
-	echo "  Actual version: $ACTUAL_LIT";
-	echo "  Installed version: $CUR_LIT";
-
-	if [ "$CUR_LIT" = "$ACTUAL_LIT" ]; then
-		echo '  Latest version is installed';
-	else
-		echo '  Lit needs update';
-		echo "  $ACTUAL_LIT > $CUR_LIT";
-		return 0;
-	fi
-
-	echo 'Checking the luvi version...';
-
-	CUR_LUVI=$(luvi -v | grep -m1 -Po 'luvi\s\K.*');
-	ACTUAL_LUVI=$(echo "$GET_LIT" | grep -o -P '(?<=\${LUVI_VERSION:-).*(?=})');
-
-	echo "  Actual version: $ACTUAL_LUVI";
-	echo "  Installed version: $CUR_LUVI";
-
-	if [ "$CUR_LUVI" = "$ACTUAL_LUVI" ]; then
-		echo '  Latest version is installed';
-	else
-		echo '  Luvi needs update';
-		echo "  $ACTUAL_LUVI > $CUR_LUVI";
-		return 0;
-	fi
-
-	echo 'Checking the luvit version...';
-
-	CUR_LUVIT=$(luvit -v | grep -m1 -Po 'luvit version:\s\K.*');
-	ACTUAL_LUVIT=$(curl https://api.github.com/repos/luvit/luvit/releases/latest | grep -o -P '(?<=\"name\": \").*(?=\",)');
-
-	echo "  Actual version: $ACTUAL_LUVIT";
-	echo "  Installed version: $CUR_LUVIT";
-
-	if [ "$CUR_LUVIT" = "$ACTUAL_LUVIT" ]; then
-		echo '  Latest version is installed';
-	else
-		echo '  Luvit needs update';
-		echo "  $ACTUAL_LUVIT > $CUR_LUVIT";
-		return 0;
-	fi
-
-	return 1;
+	echo -e "\033[38;2;50;210;255m$1\033[0m";
 }
 
-cd '/usr/bin/' || exit;
+while test $# -gt 0; do
+	case "$1" in
+		-l|-last|--lastest )
+			cecho 'Checking the lit version...'
+			LIT_VERSION=$(curl https://api.github.com/repos/luvit/lit/tags | grep -o -P '(?<=\"name\": \").*(?=\",)' | head -1);
+			cecho "Lastest lit release: $LIT_VERSION";
 
-if shouldUpdate; then
-	echo 'Update...';
-	rm lit & rm luvi & rm luvit;
-	bash -c "$GET_LIT";
+			cecho 'Checking the luvi version...'
+			LUVI_VERSION=$(curl https://api.github.com/repos/luvit/luvi/releases/latest | grep -o -P '(?<=\"tag_name\": \"v).*(?=\",)');
+			cecho "Lastest luvi release: $LUVI_VERSION";
+
+			break;
+		;;
+		-lit-ver|--lit-version )
+			LIT_VERSION=$2;
+			shift 2;
+		;;
+		-luvi-ver|--luvi-version )
+			LUVI_VERSION=$2;
+			shift 2;
+		;;
+		-h|--help)
+		cecho 'luvit-update - a update tool for lit/luvi/luvit';
+		echo ' ';
+		cecho 'luvit-update [options] [arguments]';
+		echo ' ';
+		cecho 'options:';
+		cecho '-h, --help                             Show help.';
+		cecho '-l, -last, --lastest                   Download lastest lit/luvi/luvit releases from github (by default get-lit.sh downloads a bit outdated version, due to manual update).';
+		cecho '-lit-ver XXX, --lit-version YYY        Specify an lit version.';
+		cecho '-luvi-ver XXX, --luvi-version YYY      Specify an luvit version.';
+		exit 0;
+		;;
+		*)
+			break;
+		;;
+	esac
+done;
+
+if [ ! $LIT_VERSION ] || [ ! $LUVI_VERSION ]; then
+	cecho 'Request versions from get-lit.sh';
+	GET_LIT=$(curl 'https://raw.githubusercontent.com/luvit/lit/master/get-lit.sh');
+
+	if [ !$LIT_VERSION ]; then
+		LIT_VERSION=$(cecho "$GET_LIT" | grep -o -P '(?<=\${LIT_VERSION:-).*(?=})');
+		cecho "Lit release: $LIT_VERSION (may a bit outdated)";
+	fi
+	if [ !$LUVI_VERSION ]; then
+		LUVI_VERSION=$(cecho "$GET_LIT" | grep -o -P '(?<=\${LUVI_VERSION:-).*(?=})');
+		cecho "Luvi release: $LUVI_VERSION (may a bit outdated)";
+	fi
 fi
+
+update() {
+	LUVI_ARCH=`uname -s`_`uname -m`;
+	LUVI_URL="https://github.com/luvit/luvi/releases/download/v$LUVI_VERSION/luvi-regular-$LUVI_ARCH";
+	LIT_URL="https://lit.luvit.io/packages/luvit/lit/v$LIT_VERSION.zip";
+
+	rm lit 2> /dev/null & rm luvi 2> /dev/null & rm luvit 2> /dev/null;
+
+	# Download Files
+	cecho "Downloading $LUVI_URL to luvi"
+	curl -L -f -o luvi $LUVI_URL
+	chmod +x luvi
+	cecho "Downloading $LIT_URL to lit.zip"
+	curl -L -f -o lit.zip $LIT_URL
+	# Create lit using lit
+	./luvi lit.zip -- make lit.zip lit luvi
+	# Cleanup
+	rm -f lit.zip
+	# Create luvit using lit
+	./lit make lit://luvit/luvit luvit luvi
+
+	exit 0;
+}
+
+if ! command -v lit > /dev/null
+then
+	cecho '  Lit is not installed';
+	update;
+fi
+
+if ! command -v luvi > /dev/null
+then
+	cecho '  Luvi is not installed';
+	update;
+fi
+
+if ! command -v luvit > /dev/null
+then
+	cecho '  Luvit is not installed';
+	update;
+fi
+
+LIT_VERSION_CUR=$(lit -v | grep -m1 -Po 'lit version:\s\K.*');
+cecho "Installed version of lit: $LIT_VERSION_CUR";
+
+if [ "$LIT_VERSION" != "$LIT_VERSION_CUR" ]; then
+	cecho '  Lit needs update';
+	cecho "  $LIT_VERSION != $LIT_VERSION_CUR";
+	update;
+fi
+
+LUVI_VERSION_CUR=$(luvi -v | grep -m1 -Po 'luvi v\K.*');
+cecho "Installed version of luvi: $LUVI_VERSION_CUR";
+
+if [ "$LUVI_VERSION" != "$LUVI_VERSION_CUR" ]; then
+	cecho '  Luvi needs update';
+	cecho "  $LUVI_VERSION != $LUVI_VERSION_CUR";
+	update;
+fi
+
+cecho 'No update required';

--- a/update-lit.sh
+++ b/update-lit.sh
@@ -36,7 +36,7 @@ while test $# -gt 0; do
 		echo ' ';
 		cecho 'options:';
 		cecho '-h, --help                             Show help.';
-		cecho '-l, -last, --lastest                   Download lastest lit/luvi/luvit releases from github (by default get-lit.sh downloads a bit outdated version, due to manual update).';
+		cecho '-l, -last, --lastest                   Download lastest lit/luvi/luvit releases from github (by default updater works with versions get-lit.sh that updates manually).';
 		cecho '-lit-ver XXX, --lit-version YYY        Specify an lit version.';
 		cecho '-luvi-ver XXX, --luvi-version YYY      Specify an luvit version.';
 		exit 0;

--- a/update-lit.sh
+++ b/update-lit.sh
@@ -22,11 +22,25 @@ while test $# -gt 0; do
 			break;
 		;;
 		-lit-ver|--lit-version )
-			LIT_VERSION=$2;
+			if [ "$2" = 'latest' ]; then
+				cecho 'Checking the lit version...'
+				LIT_VERSION=$(curl https://api.github.com/repos/luvit/lit/tags | grep -o -P '(?<=\"name\": \").*(?=\",)' | head -1);
+				cecho "Lastest lit release: $LIT_VERSION";
+			else
+				LIT_VERSION=$2;
+			fi
+
 			shift 2;
 		;;
 		-luvi-ver|--luvi-version )
-			LUVI_VERSION=$2;
+			if [ "$2" = 'latest' ]; then
+				cecho 'Checking the luvi version...'
+				LUVI_VERSION=$(curl https://api.github.com/repos/luvit/luvi/releases/latest | grep -o -P '(?<=\"tag_name\": \"v).*(?=\",)');
+				cecho "Lastest luvi release: $LUVI_VERSION";
+			else
+				LUVI_VERSION=$2;
+			fi
+
 			shift 2;
 		;;
 		-h|--help)

--- a/update-lit.sh
+++ b/update-lit.sh
@@ -5,8 +5,6 @@ echo 'Checking for available updates...';
 GET_LIT=$(curl 'https://raw.githubusercontent.com/luvit/lit/master/get-lit.sh')
 
 shouldUpdate() {
-	use "$GET_LIT";
-
 	if ! command -v lit > /dev/null
 	then
 		echo 'Lit not installed';
@@ -26,26 +24,29 @@ shouldUpdate() {
 	fi
 
 	CUR_LIT=$(lit -v | grep -m1 -Po 'lit version:\s\K.*');
-	ACTUAL_LIT=$(echo "$GET_LIT" | grep -o -P "(?<=\${LIT_VERSION:-).*(?=})");
+	ACTUAL_LIT=$(echo "$GET_LIT" | grep -o -P '(?<=\${LIT_VERSION:-).*(?=})');
 
 	if [ "$CUR_LIT" != "$ACTUAL_LIT" ]; then
 		echo 'Lit needs update';
+		echo "$ACTUAL_LIT > $CUR_LIT";
 		return 0;
 	fi
 
-	CUR_LUVI=$(luvi -v | grep -m1 -Po 'luvi version:\s\K.*');
-	ACTUAL_LUVI=$(echo "$GET_LIT" | grep -o -P "(?<=\${LUVI_VERSION:-).*(?=})");
+	CUR_LUVI=$(luvi -v | grep -m1 -Po 'luvi\s\K.*');
+	ACTUAL_LUVI=$(echo "$GET_LIT" | grep -o -P '(?<=\${LUVI_VERSION:-).*(?=})');
 
 	if [ "$CUR_LUVI" != "$ACTUAL_LUVI" ]; then
 		echo 'Luvi needs update';
+		echo "$ACTUAL_LUVI > $CUR_LUVI";
 		return 0;
 	fi
 
 	CUR_LUVIT=$(luvit -v | grep -m1 -Po 'luvit version:\s\K.*');
-	ACTUAL_LUVIT=$(curl https://api.github.com/repos/luvit/luvit/releases/latest | grep -o -P "(?<=\"name\": \").*(?=\",)");
+	ACTUAL_LUVIT=$(curl https://api.github.com/repos/luvit/luvit/releases/latest | grep -o -P '(?<=\"name\": \").*(?=\",)');
 
 	if [ "$CUR_LUVIT" != "$ACTUAL_LUVIT" ]; then
 		echo 'Luvit needs update';
+		echo "$ACTUAL_LUVIT > $CUR_LUVIT";
 		return 0;
 	fi
 

--- a/update-lit.sh
+++ b/update-lit.sh
@@ -7,54 +7,77 @@ GET_LIT=$(curl 'https://raw.githubusercontent.com/luvit/lit/master/get-lit.sh')
 shouldUpdate() {
 	if ! command -v lit > /dev/null
 	then
-		echo 'Lit not installed';
+		echo 'Lit is not installed';
 		return 0;
 	fi
 
 	if ! command -v luvi > /dev/null
 	then
-		echo 'Luvi not installed';
+		echo 'Luvi is not installed';
 		return 0;
 	fi
 
 	if ! command -v luvit > /dev/null
 	then
-		echo 'Luvit not installed';
+		echo 'Luvit is not installed';
 		return 0;
 	fi
+
+	echo 'Checking the lit version...';
 
 	CUR_LIT=$(lit -v | grep -m1 -Po 'lit version:\s\K.*');
 	ACTUAL_LIT=$(echo "$GET_LIT" | grep -o -P '(?<=\${LIT_VERSION:-).*(?=})');
 
-	if [ "$CUR_LIT" != "$ACTUAL_LIT" ]; then
-		echo 'Lit needs update';
-		echo "$ACTUAL_LIT > $CUR_LIT";
+	echo "  Actual version: $ACTUAL_LIT";
+	echo "  Installed version: $CUR_LIT";
+
+	if [ "$CUR_LIT" = "$ACTUAL_LIT" ]; then
+		echo '  Latest version is installed';
+	else
+		echo '  Lit needs update';
+		echo "  $ACTUAL_LIT > $CUR_LIT";
 		return 0;
 	fi
+
+	echo 'Checking the luvi version...';
 
 	CUR_LUVI=$(luvi -v | grep -m1 -Po 'luvi\s\K.*');
 	ACTUAL_LUVI=$(echo "$GET_LIT" | grep -o -P '(?<=\${LUVI_VERSION:-).*(?=})');
 
-	if [ "$CUR_LUVI" != "$ACTUAL_LUVI" ]; then
-		echo 'Luvi needs update';
-		echo "$ACTUAL_LUVI > $CUR_LUVI";
+	echo "  Actual version: $ACTUAL_LUVI";
+	echo "  Installed version: $CUR_LUVI";
+
+	if [ "$CUR_LUVI" = "$ACTUAL_LUVI" ]; then
+		echo '  Latest version is installed';
+	else
+		echo '  Luvi needs update';
+		echo "  $ACTUAL_LUVI > $CUR_LUVI";
 		return 0;
 	fi
+
+	echo 'Checking the luvit version...';
 
 	CUR_LUVIT=$(luvit -v | grep -m1 -Po 'luvit version:\s\K.*');
 	ACTUAL_LUVIT=$(curl https://api.github.com/repos/luvit/luvit/releases/latest | grep -o -P '(?<=\"name\": \").*(?=\",)');
 
-	if [ "$CUR_LUVIT" != "$ACTUAL_LUVIT" ]; then
-		echo 'Luvit needs update';
-		echo "$ACTUAL_LUVIT > $CUR_LUVIT";
+	echo "  Actual version: $ACTUAL_LUVIT";
+	echo "  Installed version: $CUR_LUVIT";
+
+	if [ "$CUR_LUVIT" = "$ACTUAL_LUVIT" ]; then
+		echo '  Latest version is installed';
+	else
+		echo '  Luvit needs update';
+		echo "  $ACTUAL_LUVIT > $CUR_LUVIT";
 		return 0;
 	fi
 
 	return 1;
 }
 
+cd '/usr/bin/' || exit;
+
 if shouldUpdate; then
 	echo 'Update...';
-	cd '/usr/bin/' || exit;
+	rm lit & rm luvi & rm luvit;
 	bash -c "$GET_LIT";
 fi


### PR DESCRIPTION
Bash script that runs [get-lit.sh](https://github.com/luvit/lit/raw/master/get-lit.sh) when `lit/luvi/luvit` is not installed or not updated.  
  
  
I wrote this to create luvit docker image for [pterodactyl](https://pterodactyl.io/) with auto-updating feature.  
  
I made it dependent on [get-lit.sh](https://github.com/luvit/lit/raw/master/get-lit.sh), without worrying about the fact that "when one component needs update, it will update all" - due to the fact that the luvit is very small, the execution [get-lit.sh](https://github.com/luvit/lit/raw/master/get-lit.sh) takes no more than a few seconds on any machine.