### PR TITLE
coro-net: fix handle leak when connect errors

### DIFF
--- a/deps/coro-net.lua
+++ b/deps/coro-net.lua
@@ -115,6 +115,7 @@ local function connect(options)
     if not secureSocket then secureSocket = require('secure-socket') end
     dsocket, err = secureSocket(socket, options.tls)
     if not dsocket then
+      if socket then socket:close() end
       return nil, err
     end
   else

--- a/deps/coro-net.lua
+++ b/deps/coro-net.lua
@@ -1,6 +1,6 @@
 --[[lit-meta
   name = "creationix/coro-net"
-  version = "3.3.0"
+  version = "3.3.1"
   dependencies = {
     "creationix/coro-channel@3.0.0",
     "creationix/coro-wrapper@3.0.0",
@@ -106,7 +106,10 @@ local function connect(options)
     socket:connect(options.path, makeCallback(options.timeout))
   end
   success, err = coroutine.yield()
-  if not success then return nil, err end
+  if not success then
+    if socket then socket:close() end
+    return nil, err
+  end
   local dsocket
   if options.tls then
     if not secureSocket then secureSocket = require('secure-socket') end

--- a/deps/coro-net.lua
+++ b/deps/coro-net.lua
@@ -107,7 +107,7 @@ local function connect(options)
   end
   success, err = coroutine.yield()
   if not success then
-    if socket then socket:close() end
+    socket:close()
     return nil, err
   end
   local dsocket
@@ -115,7 +115,7 @@ local function connect(options)
     if not secureSocket then secureSocket = require('secure-socket') end
     dsocket, err = secureSocket(socket, options.tls)
     if not dsocket then
-      if socket then socket:close() end
+      socket:close()
       return nil, err
     end
   else


### PR DESCRIPTION
Coro-net creates a new handle (whether tcp socket or a pipe) then proceeds to try connecting it. The code handling the connection failure does not seem to free the recently opened handle leading to a leak happening on `socket:connect` failures.

For ease of testing, I simulated a network error by simply commenting out `uv.getaddrinfo` and forcing it to connect to a non-existence host / port, forcing a `ECONNREFUSED` error like so:

```lua
  options.isTcp = true
  if options.isTcp then
    local res = {{addr = '127.0.0.1', port = 8000}}
    if not res then return nil, err end
    socket = uv.new_tcp()
    socket:connect(res[1].addr, res[1].port, makeCallback(options.timeout))
    ...
```

The results of doing multiple `coro_net.connect` calls with this simulation resulted in the following:
![image](https://user-images.githubusercontent.com/38175840/219938158-899cf5f8-ac61-4ba1-83f3-e86a9b786fe7.png)

With this patch it seems to behave:
![image](https://user-images.githubusercontent.com/38175840/219938171-b67b7180-ac6d-400e-baef-1a332a0e5072.png)

One thing I am not entirely sure about if it is possible for `socket` to not be nil, yet manage to fail on `socket:close()`, I assume that is not a possible scenario.