### PR TITLE
readline: also handle line feed for Enter

### DIFF
--- a/deps/readline.lua
+++ b/deps/readline.lua
@@ -300,7 +300,7 @@ end
 local keyHandlers =
 {
   -- Enter
-  {{13}, function(self)
+  {{10, 13}, function(self)
     local history = self.history
     local line = self.line
     -- Only record new history if it's non-empty and new


### PR DESCRIPTION
Is there a reason this isn't already the case? Apparently some systems will use a line feed (`\010`) instead of a carriage return (`\013`).  

Not handling line feed on those systems results in a "Unhandled Key" error when enter is pressed.

On Linux when an enter is pressed apparently line feed ('\010") is used (which makes sense) but on most systems an stty option `onlcr` automatically converts that into a carriage return, which is why readline doesn't fail on those systems.  Seems like when this `onlcr` option is not enabled readline will fail although.

This was reported as a question over on the [Discord server ](https://discord.com/channels/377572091869790210/377966865999462408/1229037907969441895) by @Be1zebub.