### PR TITLE
fix: secure-socket does not check for certificate domain

### DIFF
--- a/deps/secure-socket/biowrap.lua
+++ b/deps/secure-socket/biowrap.lua
@@ -48,6 +48,10 @@ return function (ctx, isServer, socket, handshakeComplete, servername)
 
   local function handshake(callback)
     if ssl:handshake() then
+      local cert = ssl:peer()
+      if not cert:check_host(servername) then
+        return error("The server hostname does not match the certificate's domain")
+      end
       local success, result = ssl:getpeerverification()
       socket:read_stop()
       if not success and result then

--- a/deps/secure-socket/biowrap.lua
+++ b/deps/secure-socket/biowrap.lua
@@ -17,6 +17,12 @@ limitations under the License.
 --]]
 local openssl = require('openssl')
 
+local function closeSocket(socket)
+  if not socket:is_closing() then
+    socket:close()
+  end
+end
+
 -- writeCipher is called when ssl needs something written on the socket
 -- handshakeComplete is called when the handhake is complete and it's safe
 -- onPlain is called when plaintext comes out.
@@ -48,20 +54,27 @@ return function (ctx, isServer, socket, handshakeComplete, servername)
 
   local function handshake(callback)
     if ssl:handshake() then
-      local cert = ssl:peer()
-      if not cert:check_host(servername) then
-        return error("The server hostname does not match the certificate's domain")
-      end
       local success, result = ssl:getpeerverification()
       socket:read_stop()
       if not success and result then
         for i=1, #result do
           if not result[i].preverify_ok then
             handshakeComplete("Error verifying peer: " .. result[i].error_string)
-            break
+            return closeSocket(socket)
           end
         end
       end
+
+      local cert = ssl:peer()
+      if not cert then
+        handshakeComplete("The peer did not provide a certificate")
+        return closeSocket(socket)
+      end
+      if not cert:check_host(servername) then
+        handshakeComplete("The server hostname does not match the certificate's domain")
+        return closeSocket(socket)
+      end
+
       handshakeComplete(nil, ssocket)
     end
     return flush(callback)

--- a/deps/secure-socket/init.lua
+++ b/deps/secure-socket/init.lua
@@ -33,8 +33,10 @@ return function (socket, options, callback)
     thread = coroutine.running()
   end
   bioWrap(ctx, options.server, socket, callback or function (err, ssocket)
-    return assertResume(thread, ssocket, err)
-end, options.servername)
+    if coroutine.status(thread) == 'suspended' then
+      return assertResume(thread, ssocket, err)
+    end
+  end, options.servername)
   if not callback then
     return coroutine.yield()
   end

--- a/deps/secure-socket/init.lua
+++ b/deps/secure-socket/init.lua
@@ -33,9 +33,7 @@ return function (socket, options, callback)
     thread = coroutine.running()
   end
   bioWrap(ctx, options.server, socket, callback or function (err, ssocket)
-    if coroutine.status(thread) == 'suspended' then
-      return assertResume(thread, ssocket, err)
-    end
+    return assertResume(thread, ssocket, err)
   end, options.servername)
   if not callback then
     return coroutine.yield()

--- a/tests/test-coro-http-security.lua
+++ b/tests/test-coro-http-security.lua
@@ -1,0 +1,75 @@
+local http = require 'coro-http'
+
+
+require('tap')(function (test)
+
+  local function expectNoConnection(endpoints)
+    for name, endpoint in pairs(endpoints) do
+      coroutine.wrap(function()
+        -- TODO: do we want to match against the error message?
+        local connecionSucceeded = pcall(http.getConnection, endpoints.expired, 443, true)
+        if connecionSucceeded then
+          error(string.format('a bad ceritifcate was accepted as trusted: %s - https://%s', name, endpoint))
+        end
+      end)()
+    end
+  end
+
+  local function expectConnection(endpoints)
+    for name, endpoint in pairs(endpoints) do
+      coroutine.wrap(function()
+        local connecionSucceeded, err = pcall(http.getConnection, endpoints.expired, 443, true)
+        if not connecionSucceeded then
+          error(string.format('a good certificate was rejected as untrusted: %s - https://%s - %s', name, endpoint, err))
+        end
+      end)()
+    end
+  end
+
+  test('Certificate Validation ', function ()
+    local endpoints = {
+      expired = 'expired.badssl.com',
+      wrong_host = 'wrong.host.badssl.com',
+      self_signed = 'self-signed.badssl.com',
+      untrusted_root = 'untrusted-root.badssl.com',
+    }
+    expectNoConnection(endpoints)
+  end)
+
+  test('Interception Certificates', function ()
+    local endpoints = {
+      superfish = 'superfish.badssl.com',
+      edellroot = 'edellroot.badssl.com',
+      preact_cli = 'preact-cli.badssl.com',
+      dsdtestprovider = 'dsdtestprovider.badssl.com',
+      webpack_dev_server = 'webpack-dev-server.badssl.com',
+    }
+    expectNoConnection(endpoints)
+  end)
+
+  test('Broken Cryptography', function ()
+    local endpoints = {
+      rc4 = 'rc4.badssl.com',
+      rc4_md5 = 'rc4-md5.badssl.com',
+      dh480 = 'dh480.badssl.com',
+      dh512 = 'dh512.badssl.com',
+      dh1024 = 'dh1024.badssl.com',
+      null = 'null.badssl.com',
+    }
+    expectNoConnection(endpoints)
+  end)
+
+  -- might require some workarounds
+  -- test('Secure', function ()
+  --   local endpoints = {
+  --     tls_v1_2 = 'tls-v1-2.badssl.com:1012',
+  --     sha256 = 'sha256.badssl.com',
+  --     rsa2048 = 'rsa2048.badssl.com',
+  --     ecc256 = 'ecc256.badssl.com',
+  --     ecc384 = 'ecc384.badssl.com',
+  --     -- extended_validation = "extended-validation.badssl.com/", -- bad certificate
+  --     mozilla_modern = 'mozilla-modern.badssl.com',
+  --   }
+  --   expectConnection(endpoints)
+  -- end)
+end)

--- a/tests/test-coro-http-security.lua
+++ b/tests/test-coro-http-security.lua
@@ -7,8 +7,8 @@ require('tap')(function (test)
     for name, endpoint in pairs(endpoints) do
       coroutine.wrap(function()
         -- TODO: do we want to match against the error message?
-        local connecionSucceeded = pcall(http.getConnection, endpoints.expired, 443, true)
-        if connecionSucceeded then
+        local connectionSucceeded = pcall(http.getConnection, endpoints.expired, 443, true)
+        if connectionSucceeded then
           error(string.format('a bad ceritifcate was accepted as trusted: %s - https://%s', name, endpoint))
         end
       end)()
@@ -18,15 +18,15 @@ require('tap')(function (test)
   local function expectConnection(endpoints)
     for name, endpoint in pairs(endpoints) do
       coroutine.wrap(function()
-        local connecionSucceeded, err = pcall(http.getConnection, endpoints.expired, 443, true)
-        if not connecionSucceeded then
+        local connectionSucceeded, err = pcall(http.getConnection, endpoints.expired, 443, true)
+        if not connectionSucceeded then
           error(string.format('a good certificate was rejected as untrusted: %s - https://%s - %s', name, endpoint, err))
         end
       end)()
     end
   end
 
-  test('Certificate Validation ', function ()
+  test('Certificate Validation', function ()
     local endpoints = {
       expired = 'expired.badssl.com',
       wrong_host = 'wrong.host.badssl.com',


### PR DESCRIPTION
After secure-socket verifies a certificates and deems it to be valid, it does not check whether this certificate is actually provided by the same server that claims to be the owner of the certificate.  This results in a possible attack vector where an attacker that is intercepting a connection (through a MITM attack) to provide any valid SSL certificate (for example, one they made themselves for a domain they own) and secure-socket (and by extension, coro-net/coro-http etc) would accept that certificate.

1. A connection is intercepted by an attacker between `google.com` and a user-agent using secure-socket.
2. The attacker provides their valid certificate for the domain they own `doodle.com`.
3. secure-socket will check for the validity of the certificate (which it is valid), and start encrypting the packets following that.
4. The attacker can now decrypt all packets and read what is going on with the connection, potentially stealing the user-agent session tokens, passwords, etc.

A Common Weakness Enumeration for this would be [297](https://cwe.mitre.org/data/definitions/297.html):
> 
> ```c
>cert = SSL_get_peer_certificate(ssl);
> if (cert && (SSL_get_verify_result(ssl)==X509_V_OK)) {
>
> // do secret things
> }
>```
> Even though the "verify" step returns X509_V_OK, this step does not include checking the Common Name against the name of the host. That is, there is no guarantee that the certificate is for the desired host. The SSL connection could have been established with a malicious host that provided a valid certificate.

This has been mitigated in this PR by applying an identity check using [x509:check_host](https://zhaozg.github.io/lua-openssl/modules/x509.html#x509:check_host) and error if the domain of the certificate does not match the server name.

This was caught when I was (out of curiosity)  testing out https://badssl.com/dashboard/ with coro-http. As such I also added tests for this using coro-http.

P.S: We also had a bug in how we handled coroutine resumption, where in the tests coro-net was constantly trying to resume a coroutine after it was already resumed by the openssl certificate error. That is now fixed by checking the thread status, and only attempt resuming it if it was suspended.

