### PR TITLE
secuer-socket: patch version bump

### DIFF
--- a/deps/secure-socket/package.lua
+++ b/deps/secure-socket/package.lua
@@ -1,6 +1,6 @@
 return {
   name = "luvit/secure-socket",
-  version = "1.2.3",
+  version = "1.2.4",
   homepage = "https://github.com/luvit/luvit/blob/master/deps/secure-socket",
   description = "Wrapper for luv streams to apply ssl/tls",
   dependencies = {


### PR DESCRIPTION
Includes:
- https://github.com/luvit/lit/pull/296: fixes error messages on invalid certificates.
- https://github.com/luvit/lit/pull/326: adds identity checks to properly secure connections.

@squeek502 / @truemedian  A new Lit release would be appreciated 