### PR TITLE
fix: coro-channel attempts to resume running thread

### DIFF
--- a/deps/coro-channel.lua
+++ b/deps/coro-channel.lua
@@ -1,6 +1,6 @@
 --[[lit-meta
   name = "creationix/coro-channel"
-  version = "3.0.3"
+  version = "3.0.4"
   homepage = "https://github.com/luvit/lit/blob/master/deps/coro-channel.lua"
   description = "An adapter for wrapping uv streams as coro-streams."
   tags = {"coro", "adapter"}
@@ -120,10 +120,18 @@ end
 
 local function makeWrite(socket, closer)
 
+  local hasYielded, hasReturned
+  local success, err
   local function wait()
     local thread = coroutine.running()
-    return function (err)
-      assertResume(thread, err)
+    return function (cb_err)
+      if hasYielded then
+        hasYielded = false
+        assertResume(thread, cb_err)
+      else
+        err = cb_err
+        hasReturned = true
+      end
     end
   end
 
@@ -137,21 +145,27 @@ local function makeWrite(socket, closer)
     if chunk == nil then
       closer.written = true
       closer.check()
-      local success, err = socket:shutdown(wait())
+      success, err = socket:shutdown(wait())
       if not success then
         return nil, err
       end
-      err = coroutine.yield()
+      if not hasReturned then
+        hasYielded = true
+        err = coroutine.yield()
+      end
       return not err, err
     end
 
-    local success, err = socket:write(chunk, wait())
+    success, err = socket:write(chunk, wait())
     if not success then
       closer.errored = err
       closer.check()
       return nil, err
     end
-    err = coroutine.yield()
+    if not hasReturned then
+      hasYielded = true
+      err = coroutine.yield()
+    end
     return not err, err
   end
 

--- a/tests/test-coro-channel.lua
+++ b/tests/test-coro-channel.lua
@@ -1,31 +1,179 @@
+local uv = require 'uv'
 local channel = require 'coro-channel'
+
 local wrapWrite = channel.wrapWrite
 
-require('tap')(function (test)
-  test('Writer: finish writing instantly', function ()
-    local ssocket = {
-      is_closing = function()
-        return true
-      end
-    }
 
-    local success, err
-    local write = wrapWrite(ssocket)
+local writeCallbacks = {
+  successful_write = function(self, chunk, callback)
+    self.writeBuf = chunk
+    callback()
+    return true
+  end,
+  delayed_successful_write = function(self, chunk, callback)
+    local timer = uv.new_timer()
+    timer:start(50, 0, function ()
+      timer:stop()
+      timer:close()
+      self.writeBuf = chunk
+      callback()
+    end)
+    return true
+  end,
 
-    ssocket.write = function(self, chunk, callback)
+  failed_call_write = function()
+    return nil, 'call failed'
+  end,
+  failed_callback_write = function(_, _, callback)
+    callback('callback failed')
+    return true
+  end,
+  delayed_failed_callback_write = function(_, _, callback)
+    local timer = uv.new_timer()
+    timer:start(50, 0, function ()
+      timer:stop()
+      timer:close()
+      callback('callback failed')
+    end)
+    return true
+  end,
+}
+
+-- create a dummy socket for a write/read.
+-- override methods as needed to control the behavior.
+-- TODO: add read_start/read_stop
+local function dummySocket()
+  return {
+    -- used throughout the tests to track the socket state
+    is_shutdown = false,
+    is_closed = false,
+    writeBuf = nil,
+
+    write = writeCallbacks.successful_write,
+    is_closing = function()
+      return false
+    end,
+    close = function(self)
+      self.is_closed = true
+    end,
+    shutdown = function(self, callback)
+      self.is_shutdown = true
       callback()
       return true
-    end
-    success, err = write('succeeds writing')
-    assert(success)
-    assert(not err) -- if an error message is returned while success is true closer won't be triggered
+    end,
+  }
+end
 
-    ssocket.write = function(self, chunk, callback)
-      callback('error message')
-      return false, 'error message'
+-- Attempt a write and check the written chunk & success/failure state.
+--  - if a write is expected to fail, set `expectFailure` to the expected error return.
+--  - `socket.writeBuf` should be set by the write method so it can verify written data
+--    and compare it to the passed `chunk` argument.
+--  - if `socket.wrappedWrite` exists, it will be used instead of calling `wrapWrite` again,
+--    this is useful when testing multiple write/read states.
+local function expectWrite(socket, chunk, expectFailure)
+  local write = socket.wrappedWrite or wrapWrite(socket)
+  local success, err = write(chunk)
+
+  if not expectFailure then
+    assert(success, 'write failed, expected a successful write')
+    assert(not err, 'write was successful but an error was returned') -- happens if write returned `true, "error"`
+    assert(socket.writeBuf == chunk, 'write was successful but written chunk mismatches')
+  else
+    assert(not success, 'write succeeded, expected a failed write')
+    assert(err == expectFailure, 'write returned error does not match expected error')
+  end
+
+  return success, err
+end
+
+-- TODO: add reader/closer tests
+require('tap')(function (test)
+
+  test('writer: finish writing instantly', function ()
+    local ssocket = dummySocket()
+
+    -- successful writes
+    ssocket.write = writeCallbacks.successful_write
+    expectWrite(ssocket, 'placeholder: write succeeds')
+    expectWrite(ssocket, false)
+    expectWrite(ssocket, {})
+
+    -- failed write: the call returned failure
+    ssocket.write = writeCallbacks.failed_call_write
+    expectWrite(ssocket, 'placeholder: write fails', 'call failed')
+    assert(ssocket.is_closed, 'expected socket to close after error')
+
+    -- failed write: the call is successful but callback returned failure
+    ssocket.write = writeCallbacks.failed_callback_write
+    expectWrite(ssocket, 'placeholder: write fails', 'callback failed')
+  end)
+
+  test('writer: delayed write', function ()
+    local ssocket = dummySocket()
+
+    -- successful writes
+    ssocket.write = writeCallbacks.delayed_successful_write
+    expectWrite(ssocket, false)
+    expectWrite(ssocket, {})
+
+    -- failed write
+    ssocket.write = writeCallbacks.delayed_failed_callback_write
+    expectWrite(ssocket, 'placeholder: write fails', 'callback failed')
+  end)
+
+  test('writer: mixed instantaneous/delayed writes', function ()
+    local ssocket = dummySocket()
+    -- share states between writes
+    -- this test tries to mix up and corrupt the states
+    ssocket.wrappedWrite = wrapWrite(ssocket)
+
+    -- successful writes
+    ssocket.write = writeCallbacks.successful_write
+    expectWrite(ssocket, {})
+    ssocket.write = writeCallbacks.delayed_successful_write
+    expectWrite(ssocket, {})
+    -- failed writes
+    ssocket.write = writeCallbacks.delayed_failed_callback_write
+    expectWrite(ssocket, 'placeholder: write fails', 'callback failed')
+    ssocket.write = writeCallbacks.failed_call_write
+    expectWrite(ssocket, 'placeholder: write fails', 'call failed')
+    assert(ssocket.is_closed, 'expected socket to close after error')
+
+    -- reset states, redo tests in mixed order in case order matters
+    ssocket.wrappedWrite = wrapWrite(ssocket)
+
+    ssocket.write = writeCallbacks.delayed_failed_callback_write
+    expectWrite(ssocket, 'placeholder: write fails', 'callback failed')
+    ssocket.write = writeCallbacks.delayed_successful_write
+    expectWrite(ssocket, {})
+    ssocket.write = writeCallbacks.failed_call_write
+    expectWrite(ssocket, 'placeholder: write fails', 'call failed')
+    assert(ssocket.is_closed, 'expected socket to close after error')
+    ssocket.write = writeCallbacks.successful_write
+    expectWrite(ssocket, {})
+  end)
+
+  test('writer: an empty chunk triggers close', function ()
+    local ssocket = dummySocket()
+
+    ssocket.wrappedWrite = wrapWrite(ssocket)
+    expectWrite(ssocket, nil)
+    assert(ssocket.is_shutdown, 'expected socket to shutdown')
+    assert(ssocket.is_closed, 'expected socket to close')
+    expectWrite(ssocket, 'placeholder: write fails', 'already shutdown')
+
+    -- do we catch socket:shutdown() failing properly?
+    ssocket.wrappedWrite = wrapWrite(ssocket)
+    ssocket.shutdown = function(_, callback)
+      callback('failed to shutdown')
+      return true
     end
-    success, err = write('failed write')
-    assert(not success) -- apparently this could be either false or nil
-    assert(err == 'error message')
+    expectWrite(ssocket, nil, 'failed to shutdown')
+
+    ssocket.wrappedWrite = wrapWrite(ssocket)
+    ssocket.shutdown = function(_, callback)
+      return nil, 'failed to call shutdown'
+    end
+    expectWrite(ssocket, nil, 'failed to call shutdown')
   end)
 end)

--- a/tests/test-coro-channel.lua
+++ b/tests/test-coro-channel.lua
@@ -1,0 +1,31 @@
+local channel = require 'coro-channel'
+local wrapWrite = channel.wrapWrite
+
+require('tap')(function (test)
+  test('Writer: finish writing instantly', function ()
+    local ssocket = {
+      is_closing = function()
+        return true
+      end
+    }
+
+    local success, err
+    local write = wrapWrite(ssocket)
+
+    ssocket.write = function(self, chunk, callback)
+      callback()
+      return true
+    end
+    success, err = write('succeeds writing')
+    assert(success)
+    assert(not err) -- if an error message is returned while success is true closer won't be triggered
+
+    ssocket.write = function(self, chunk, callback)
+      callback('error message')
+      return false, 'error message'
+    end
+    success, err = write('failed write')
+    assert(not success) -- apparently this could be either false or nil
+    assert(err == 'error message')
+  end)
+end)


### PR DESCRIPTION
Consider the following minimal-reproduction code:
```lua
local ssocket = {
  -- will finish the write instantly
  write = function(self, chunk, callback)
    callback()
    return true
  end,
  
  -- irrelevant, just to make the example work
  is_closing = function()
    return true
  end 
}

local write = require("coro-channel").wrapWrite(ssocket)
write("") -- it is important to provide any value here, because a nil value will close the socket instead of attempting a write
```
This will produce the following error
```
ncaught exception:
cannot resume running coroutine
stack traceback:
	/home/bilal/deps/coro-channel.lua:16: in function 'assertResume'
	/home/bilal/deps/coro-channel.lua:126: in function 'callback'
	/home/bilal/test.lua:5: in function 'write'
	/home/bilal/deps/coro-channel.lua:148: in function 'write'
	/home/bilal/test.lua:17: in function 'fn'
	[string "bundle:deps/require.lua"]:309: in function 'require'
	[string "bundle:/main.lua"]:128: in function <[string "bundle:/main.lua"]:20>
stack traceback:
	[C]: in function 'error'
	/home/bilal/deps/coro-channel.lua:16: in function 'assertResume'
	/home/bilal/deps/coro-channel.lua:126: in function 'callback'
	/home/bilal/test.lua:5: in function 'write'
	/home/bilal/deps/coro-channel.lua:148: in function 'write'
	/home/bilal/test.lua:17: in function 'fn'
	[string "bundle:deps/require.lua"]:309: in function 'require'
	[string "bundle:/main.lua"]:128: in function <[string "bundle:/main.lua"]:20>
stack traceback:
	[C]: in function 'error'
	[string "bundle:/deps/utils.lua"]:42: in function 'assertResume'
	[string "bundle:/init.lua"]:53: in function <[string "bundle:/init.lua"]:48>
	[C]: in function 'xpcall'
	[string "bundle:/init.lua"]:48: in function 'fn'
	[string "bundle:deps/require.lua"]:309: in function <[string "bundle:deps/require.lua"]:266>
```

This happens because the write call at [coro-channel.lua#L148](https://github.com/luvit/lit/blob/master/deps/coro-channel.lua#L148 ) returns immediately, the callback produced by `wait()` is also called immediately, this callback will attempt to resume the current thread, but the `coroutine.yield` line has not yet been executed (since write finished instantly).

This minimal example is basically what happens when a socket is wrapped with `secure-socket` , which will attempt to optimize empty writes by returning immediately (in the flush function over [here](https://github.com/luvit/lit/blob/master/deps/secure-socket/biowrap.lua#L48-L51) it will execute the callback and return early).

Which leads to `https`/`wss` requests made by coro-net crash when code such as `require'coro-http'.request("POST", "https://google.com", {}, "")` is ran (secure-socket sees that we are trying to write an empty chunk for the payload, so it decides to just return early and immediately since such a write will be ignored by libuv anyways).


The solution suggested in this PR is to basically keep track of when the thread has yielded, and if the wait callback is called before we reach yield, then we don't bother with resuming current thread and just return, similar to what we did with `coro-split`.

fixes #303.



