### PR TITLE
fix: invalid usage of uv.run() in command runner

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -37,14 +37,10 @@ local aliases = { ["-v"] = "version", ["-h"] = "help" }
 local commandLine = {}
 
 function commandLine.run()
-  coroutine.wrap(commandLine.processUserInput)()
-  return uv.run()
-end
-
-function commandLine.processUserInput()
   local command = commandLine.processArguments()
   local success, errorMessage = xpcall(function()
-    return commandLine.executeCommand(command)
+    coroutine.wrap(commandLine.executeCommand)(command)
+    return uv.run()
   end, debug.traceback)
 
   if not success then


### PR DESCRIPTION
We have been calling `uv.run()` from inside of a
libuv callback, which is not allowed. This moves
the original call to `uv.run()` inside of the main xpcall, which is where it is necessary.

This allows the first call to `uv.run()` to be
completely finished before we attempt to exit and
call `uv.run()` again.