### PR TITLE
Bump lit to 3.9.0 and luvi to 2.15.0

### DIFF
--- a/package.lua
+++ b/package.lua
@@ -1,13 +1,13 @@
 return {
   name = "luvit/lit",
-  version = "3.8.5",
+  version = "3.9.0",
   homepage = "https://github.com/luvit/lit",
   description = "The Luvit Invention Toolkit is a luvi app that handles dependencies and luvi builds.",
   tags = {"lit", "meta"},
   license = "Apache 2",
   author = { name = "Tim Caswell" },
   luvi = {
-    version = "v2.12.0",
+    version = "v2.15.0",
     flavor = "regular",
   },
   dependencies = {


### PR DESCRIPTION
There have a been a lot of changes and years since 3.8.5 (9b0f3be64e9b8dd65bece121ce9a2ae8d8ac1c00 and 84fc5d729f1088b3b93bc9a55d1f7a245bca861d). I think it's time we update to the current luvi and give lit a minor bump. `get-lit` changes will follow.