### PR TITLE
SHA1: `table.floor` -> `math.floor`

### DIFF
--- a/deps/sha1/init.lua
+++ b/deps/sha1/init.lua
@@ -22,7 +22,7 @@ local tohex = bit.tohex
 
 local byte = string.byte
 local concat = table.concat
-local floor = table.floor
+local floor = math.floor
 
 local hasFFi, ffi = pcall(require, "ffi")
 local newBlock = hasFFi and function ()


### PR DESCRIPTION
There seems to be a slight mistake in the SHA1 library where `floor` was incorrectly assigned as `table.floor` which isn't a thing...
TL;DR: A runtime error.

Just to make sure I wasn't losing my brain, I checked usages of `floor` in the file to confirm that they align with actual mathematical use and not any kind of magical table operations.

But anyways yeah, just a `table.floor` -> `math.floor`.