### PR TITLE
secure-socket: only do peer verification in client mode

### DIFF
--- a/deps/secure-socket/biowrap.lua
+++ b/deps/secure-socket/biowrap.lua
@@ -65,14 +65,16 @@ return function (ctx, isServer, socket, handshakeComplete, servername)
         end
       end
 
-      local cert = ssl:peer()
-      if not cert then
-        handshakeComplete("The peer did not provide a certificate")
-        return closeSocket(socket)
-      end
-      if not cert:check_host(servername) then
-        handshakeComplete("The server hostname does not match the certificate's domain")
-        return closeSocket(socket)
+      if not isServer then
+        local cert = ssl:peer()
+        if not cert then
+          handshakeComplete("The peer did not provide a certificate")
+          return closeSocket(socket)
+        end
+        if not cert:check_host(servername) then
+          handshakeComplete("The server hostname does not match the certificate's domain")
+          return closeSocket(socket)
+        end
       end
 
       handshakeComplete(nil, ssocket)


### PR DESCRIPTION
Peer verification added in https://github.com/luvit/lit/commit/22b73dd5873e0c0a6cc65e3ac6d3dbb223a7133a is meant to be ran by the client as a way to verify the host it is talking to is indeed who it claims to be.  This logic does not make sense to be running on a server context though since asking the client to provide a x509 certificate is not part of the handshake.

This PR fixes a bug where running secure-socket in the context of a server fails with the error:
```lua
/home/bilal/test/deps/coro-net.lua:163: The peer did not provide a certificate
stack traceback:
	[C]: in function 'assert'
	/home/bilal/test/deps/coro-net.lua:163: in function </home/bilal/test/deps/coro-net.lua:159>
	[C]: in function 'xpcall'
	/home/bilal/test/deps/coro-net.lua:159: in function </home/bilal/test/deps/coro-net.lua:158>

```
you can run a coro-http server or a weblit server to replicate the issue. Tested with a self-signed certificate.