### PR TITLE
adoption: bump luvit/resource to 2.1.1 for re-release

### DIFF
--- a/deps/resource.lua
+++ b/deps/resource.lua
@@ -18,7 +18,7 @@ limitations under the License.
 
 --[[lit-meta
   name = "luvit/resource"
-  version = "2.1.0"
+  version = "2.1.1"
   license = "Apache 2"
   homepage = "https://github.com/luvit/luvit/blob/master/deps/resource.lua"
   description = "Utilities for loading relative resources"


### PR DESCRIPTION
This was missed during the original adoption. This was the only package already under `luvit/` so that the bulk publish for the new dependencies was not applied here because the version already existed.

After this is merged `luvit/resource` needs to be published on lit.