### PR TITLE
luvit-loader: fix uv fs_access call

### DIFF
--- a/luvit-loader.lua
+++ b/luvit-loader.lua
@@ -237,7 +237,7 @@ local function searcher(path)
       return 'bundle:' .. fullPath, loader
     end
   else
-    if uv.fs_access(fullPath) then
+    if uv.fs_access(fullPath, 'r') then
       return fullPath, loader
     end
   end


### PR DESCRIPTION
fixes:

	[string "bundle:luvit-loader.lua"]:240: bad argument #2 to 'fs_access' (Expected string or integer for file access mode check)