### PR TITLE
Bump versions for get-lit (sh, ps1)

### DIFF
--- a/get-lit.ps1
+++ b/get-lit.ps1
@@ -1,3 +1,5 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
 
 $LUVI_VERSION = "2.15.0"
 $LIT_VERSION = "3.9.0"
@@ -11,10 +13,20 @@ if (test-path env:LUVI_ARCH) {
   if ([System.Environment]::Is64BitProcess) {
     $LUVI_ARCH = "Windows-amd64"
   } else {
-    $LUVI_ARCH = "Windows-x86"
+    $LUVI_ARCH = "Windows-ia32"
   }
 }
-$LUVI_URL = "https://github.com/luvit/luvi/releases/download/v$LUVI_VERSION/luvi-$LUVI_ARCH-luajit-regular.exe"
+if ([version]"2.15.0" -le [version]$LUVI_VERSION) {
+    if ($LUVI_ARCH -eq "Windows-i386") {
+        $LUVI_ARCH = "Windows-x86"
+    }
+    $LUVI_URL = "https://github.com/luvit/luvi/releases/download/v$LUVI_VERSION/luvi-$LUVI_ARCH-luajit-regular.exe"
+} else {
+    if ($LUVI_ARCH -eq "Windows-x86") {
+        $LUVI_ARCH = "Windows-ia32"
+    }
+    $LUVI_URL = "https://github.com/luvit/luvi/releases/download/v$LUVI_VERSION/luvi-regular-$LUVI_ARCH.exe"
+}
 $LIT_URL = "https://lit.luvit.io/packages/luvit/lit/v$LIT_VERSION.zip"
 
 function Download-File {

--- a/get-lit.sh
+++ b/get-lit.sh
@@ -3,8 +3,16 @@ set -eu
 LUVI_VERSION=${LUVI_VERSION:-2.15.0}
 LIT_VERSION=${LIT_VERSION:-3.9.0}
 
-LUVI_ARCH=`uname -s`-`uname -m`
-LUVI_URL="https://github.com/luvit/luvi/releases/download/v$LUVI_VERSION/luvi-$LUVI_ARCH-luajit-regular"
+LUVI_OS=$(uname -s)
+LUVI_ARCH=$(uname -m)
+
+# 2.15.0 or higher uses a different URL
+if [ "2.15.0" = "$(printf '%s\n%s\n' "2.15.0" "$LUVI_VERSION" | sort -V | head -n 1)" ]; then
+	LUVI_URL="https://github.com/luvit/luvi/releases/download/v$LUVI_VERSION/luvi-${LUVI_OS}-${LUVI_ARCH}-luajit-regular"
+else
+	LUVI_URL="https://github.com/luvit/luvi/releases/download/v$LUVI_VERSION/luvi-regular-${LUVI_OS}_$LUVI_ARCH"
+fi
+
 LIT_URL="https://lit.luvit.io/packages/luvit/lit/v$LIT_VERSION.zip"
 
 # Download Files


### PR DESCRIPTION
Powershell script was also modified to just quit if any error happens, like with the `sh` script.