### PR TITLE
get-lit: improve luvit installation

### DIFF
--- a/get-lit.ps1
+++ b/get-lit.ps1
@@ -4,6 +4,7 @@ Set-StrictMode -Version Latest
 $LUVI_PREFIX = if ($env:LUVI_PREFIX) { $env:LUVI_PREFIX } else { $PWD }
 $LUVI_ENGINE = if ($env:LUVI_ENGINE) { $env:LUVI_ENGINE } else { "luajit" }
 $LUVI_VERSION = if ($env:LUVI_VERSION) { $env:LUVI_VERSION } else { "2.15.0" }
+$LUVI_FLAVOR = if ($env:LUVI_FLAVOR) { $env:LUVI_FLAVOR } else { "regular" }
 $LIT_VERSION = if ($env:LIT_VERSION) { $env:LIT_VERSION } else { "3.9.0" }
 $LUVIT_VERSION = if ($env:LUVIT_VERSION) { $env:LUVIT_VERSION } else { "latest" }
 
@@ -98,13 +99,13 @@ if ($LIT_VERSION -ne "latest") { $LIT_VERSION = "v${LIT_VERSION}" }
 if ($LUVIT_VERSION -ne "latest") { $LUVIT_VERSION = "v${LUVIT_VERSION}" }
 
 if (${LUVI_VERSION} -eq "latest") {
-  $luvi_url = "https://github.com/luvit/luvi/releases/latest/download/luvi-${LUVI_OS}-${LUVI_ARCH}-${LUVI_ENGINE}-regular${exe_suffix}"
+  $luvi_url = "https://github.com/luvit/luvi/releases/latest/download/luvi-${LUVI_OS}-${LUVI_ARCH}-${LUVI_ENGINE}-${LUVI_FLAVOR}${exe_suffix}"
 }
 elseif (VersionGTE $LUVI_VERSION "2.15.0") {
-  $luvi_url = "https://github.com/luvit/luvi/releases/download/${LUVI_VERSION}/luvi-${LUVI_OS}-${LUVI_ARCH}-${LUVI_ENGINE}-regular${exe_suffix}"
+  $luvi_url = "https://github.com/luvit/luvi/releases/download/${LUVI_VERSION}/luvi-${LUVI_OS}-${LUVI_ARCH}-${LUVI_ENGINE}-${LUVI_FLAVOR}${exe_suffix}"
 }
 else {
-  $luvi_url = "https://github.com/luvit/luvi/releases/download/${LUVI_VERSION}/luvi-regular-${LUVI_OS}_${LUVI_ARCH}${exe_suffix}"
+  $luvi_url = "https://github.com/luvit/luvi/releases/download/${LUVI_VERSION}/luvi-${LUVI_FLAVOR}-${LUVI_OS}_${LUVI_ARCH}${exe_suffix}"
 }
 $lit_url = "https://lit.luvit.io/packages/luvit/lit/${LIT_VERSION}.zip"
 $luvit_url = "https://lit.luvit.io/packages/luvit/luvit/${LUVIT_VERSION}.zip"

--- a/get-lit.sh
+++ b/get-lit.sh
@@ -6,6 +6,7 @@ LUVI_PREFIX=${LUVI_PREFIX:-${PWD}}
 LUVI_OS=${LUVI_OS:-"$(uname -s)"}
 LUVI_ARCH=${LUVI_ARCH:-"$(uname -m)"}
 LUVI_ENGINE=${LUVI_ENGINE:-"luajit"}
+LUVI_FLAVOR=${LUVI_FLAVOR:-"regular"}
 
 LUVI_VERSION=${LUVI_VERSION:-"2.15.0"}
 LIT_VERSION=${LIT_VERSION:-"3.9.0"}
@@ -63,14 +64,14 @@ version_gte() {
 [ "${LIT_VERSION}" != "latest" ] && LIT_VERSION="v${LIT_VERSION}"
 [ "${LUVIT_VERSION}" != "latest" ] && LUVIT_VERSION="v${LUVIT_VERSION}"
 
-_luvi_url="https://github.com/luvit/luvi/releases/download/${LUVI_VERSION}/luvi-regular-${LUVI_OS}_${LUVI_ARCH}"
+_luvi_url="https://github.com/luvit/luvi/releases/download/${LUVI_VERSION}/luvi-${LUVI_FLAVOR}-${LUVI_OS}_${LUVI_ARCH}"
 _lit_url="https://lit.luvit.io/packages/luvit/lit/${LIT_VERSION}.zip"
 _luvit_url="https://lit.luvit.io/packages/luvit/luvit/${LUVIT_VERSION}.zip"
 
 if [ "${LUVI_VERSION}" = "latest" ]; then # select the latest endpoint
-    _luvi_url="https://github.com/luvit/luvi/releases/latest/download/luvi-${LUVI_OS}-${LUVI_ARCH}-${LUVI_ENGINE}-regular"
+    _luvi_url="https://github.com/luvit/luvi/releases/latest/download/luvi-${LUVI_OS}-${LUVI_ARCH}-${LUVI_ENGINE}-${LUVI_FLAVOR}"
 elif version_gte "${LUVI_VERSION}" "2.15.0"; then # select the new release format
-    _luvi_url="https://github.com/luvit/luvi/releases/download/${LUVI_VERSION}/luvi-${LUVI_OS}-${LUVI_ARCH}-${LUVI_ENGINE}-regular"
+    _luvi_url="https://github.com/luvit/luvi/releases/download/${LUVI_VERSION}/luvi-${LUVI_OS}-${LUVI_ARCH}-${LUVI_ENGINE}-${LUVI_FLAVOR}"
 fi
 
 echo "[+] Installing luvit, lit and luvi to ${LUVI_PREFIX}"


### PR DESCRIPTION
Overhauls the get-lit scripts to support new luvi versioning, and other QoL improvements.

### Changes overview
- Support installing new luvi's release format as well as the old format.
- Allow the user to specify the Lua engine, architecture, OS, Luvi flavor, Luvit version and installation directory.
- Better OS and architecture detection.
- Retry on download failure, good for when the Lit server is acting up.
- Make it possible to pull the latest release of luvit, luvi or lit by simply specifying `latest`.
- Better compatibility error handing between the various components.
- Better logging and cleaning.
- Add Linux/Unix support for the PowerShell script.
- Bumps Lit version to `3.9.0` from `3.8.5`.

### Notes
- Raises the minimum required version of Curl to 7.12.3 (2004), required for `--retry` support.
- The minimum required version of PowerShell stays +3.0.
- Dropped the legacy `WebClient` PowerShell API in favour of `Invoke-WebRequest`.

### Possible to-dos
- Hide `lit make` output into a log file, which is only cleaned on successful runs.
- Use `latest` as a default version for luvi and lit.
- Add more compatibility checks between luvi, luvit and lit.

Tested most of the features I could on a Windows 10 machine (PS 5.1), PowerShell +7 on Linux and the sh script on Linux. I'm not exactly good at shell scripting, so hopefully this looks clean enough!
Most of this is @truemedian's work, many thanks to him!

Supersedes #353 and previous attempts.