### PR TITLE
secure-socket: Use luvit/lit for the package URL

### DIFF
--- a/deps/secure-socket/package.lua
+++ b/deps/secure-socket/package.lua
@@ -1,7 +1,7 @@
 return {
   name = "luvit/secure-socket",
   version = "1.2.4",
-  homepage = "https://github.com/luvit/luvit/blob/master/deps/secure-socket",
+  homepage = "https://github.com/luvit/lit/blob/master/deps/secure-socket",
   description = "Wrapper for luv streams to apply ssl/tls",
   dependencies = {
     "luvit/resource@2.1.0"


### PR DESCRIPTION
luvit repo does not contain secure-socket, resulting in 404.

Also, why not bump the version soon?